### PR TITLE
fix: Remove giving subdir path as package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,15 @@ dependencies = [
   "h5py>=3.13.0",
 ]
 
+[tool.hatch.build.targets.sdist]
+# hatchling always includes:
+# pyproject.toml, .gitignore, any README, any LICENSE, AUTHORS
+only-include = [
+    "/src",
+    "/tests",
+    "/CITATION.cff"
+]
+
 [dependency-groups]
 test = [
     "pytest>=8.3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-packages = ["src/quantem"]
-
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",


### PR DESCRIPTION
Resolves https://github.com/ophusgroup/quantem/issues/61 (c.f. https://github.com/ophusgroup/quantem/issues/61#issuecomment-2921327542)

Amends PR https://github.com/ophusgroup/quantem/pull/64

This PR seems to indicate that the tests aren't working properly, and so aren't properly installing the library from development.