### PR TITLE
`typealias` no longer allowing string (forward reference) in Python 3.13

### DIFF
--- a/src/quantem/core/utils/validators.py
+++ b/src/quantem/core/utils/validators.py
@@ -14,11 +14,11 @@ if TYPE_CHECKING:
     import torch
     TensorLike: TypeAlias = ArrayLike | torch.Tensor
 else:
+    TensorLike: TypeAlias = ArrayLike
     if config.get("has_torch"):
         import torch
     if config.get("has_cupy"):
         import cupy as cp
-    TensorLike: TypeAlias = ArrayLike  # fallback when torch is not available
 
 # --- Dataset Validation Functions ---
 def ensure_valid_array(

--- a/src/quantem/core/utils/validators.py
+++ b/src/quantem/core/utils/validators.py
@@ -12,14 +12,13 @@ from quantem.core.utils import array_funcs as af
 if TYPE_CHECKING:
     import cupy as cp
     import torch
+    TensorLike: TypeAlias = ArrayLike | torch.Tensor
 else:
     if config.get("has_torch"):
         import torch
     if config.get("has_cupy"):
         import cupy as cp
-
-TensorLike: TypeAlias = ArrayLike | "torch.Tensor"
-
+    TensorLike: TypeAlias = ArrayLike  # fallback when torch is not available
 
 # --- Dataset Validation Functions ---
 def ensure_valid_array(


### PR DESCRIPTION
### What this PR does

Closes #136 

In python 3.13, the string `"torch.Tensor"` is no longer supported (forward reference).

### What should reviewer(s) do
- [x] No public API change