### PR TITLE
`Dataset3d` support `show()` 

### DIFF
--- a/src/quantem/core/datastructures/dataset3d.py
+++ b/src/quantem/core/datastructures/dataset3d.py
@@ -5,6 +5,7 @@ from numpy.typing import NDArray
 
 from quantem.core.datastructures.dataset import Dataset
 from quantem.core.utils.validators import ensure_valid_array
+from quantem.core.visualization import show_2d
 from quantem.core.visualization.visualization_utils import ScalebarConfig
 
 
@@ -217,15 +218,12 @@ class Dataset3d(Dataset):
         >>> data.show(suptitle="Diffraction patterns")  # with super title
         >>> fig, axes = data.show(returnfig=True)  # get figure for customization
         """
-        from quantem.core.visualization import show_2d
-
         if index is not None:
             # Handle negative index
             actual_index = index if index >= 0 else self.shape[0] + index
             default_title = title if title is not None else f"Frame {actual_index}"
             result = self[index].show(scalebar=scalebar, title=default_title, **kwargs)
             return result if returnfig else None
-
         # Show all frames in a grid
         n = self.shape[0]
         nrows = (n + ncols - 1) // ncols
@@ -244,7 +242,6 @@ class Dataset3d(Dataset):
                     row_titles.append("")
             arrays.append(row_arrays)
             titles.append(row_titles)
-
         fig, axes = show_2d(arrays, scalebar=scalebar, title=titles, **kwargs)
         if suptitle is not None:
             fig.suptitle(suptitle, fontsize=14)

--- a/tests/datastructures/test_dataset3d_show.py
+++ b/tests/datastructures/test_dataset3d_show.py
@@ -1,0 +1,87 @@
+"""Tests for Dataset3d.show() frame selection logic."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from quantem.core.datastructures import Dataset3d
+
+
+@pytest.fixture
+def dataset_with_10_frames():
+    """Create a Dataset3d with 10 frames for testing."""
+    return Dataset3d.from_array(np.random.rand(10, 8, 8))
+
+
+@pytest.fixture
+def dataset_with_100_frames():
+    """Create a Dataset3d with 100 frames for testing default max behavior."""
+    return Dataset3d.from_array(np.random.rand(100, 8, 8))
+
+
+def extract_frame_indices_from_figure(fig):
+    """Extract frame indices from subplot titles like 'Frame 0', 'Frame 1', etc."""
+    return [
+        int(ax.get_title().split()[-1])
+        for ax in fig.get_axes()
+        if ax.get_title().startswith("Frame ")
+    ]
+
+
+class TestShowInputValidation:
+    """Test that invalid inputs raise clear errors."""
+
+    @pytest.mark.parametrize("kwargs,match", [
+        ({"step": 0}, "cannot be zero"),
+        ({"start": 100}, "out of bounds"),
+        ({"start": -100}, "out of bounds"),
+        ({"start": 5, "end": 5}, "No frames to display"),
+        ({"ncols": 0}, "ncols must be >= 1"),
+        ({"ncols": -1}, "ncols must be >= 1"),
+        ({"max": 0}, "max must be >= 1"),
+        ({"max": -1}, "max must be >= 1"),
+    ])
+    def test_raises_value_error(self, dataset_with_10_frames, kwargs, match):
+        with pytest.raises(ValueError, match=match):
+            dataset_with_10_frames.show(**kwargs)
+
+
+class TestShowFrameSelection:
+    """Test frame selection with start, end, step, max combinations."""
+
+    @pytest.mark.parametrize("kwargs,expected_indices", [
+        ({}, list(range(20))),
+        ({"max": 5}, [0, 1, 2, 3, 4]),
+        ({"max": None}, list(range(100))),
+        ({"start": 90}, list(range(90, 100))),
+        ({"start": 95, "max": 3}, [95, 96, 97]),
+    ])
+    def test_large_dataset(self, dataset_with_100_frames, kwargs, expected_indices):
+        fig, _ = dataset_with_100_frames.show(returnfig=True, **kwargs)
+        assert extract_frame_indices_from_figure(fig) == expected_indices
+        plt.close(fig)
+
+    @pytest.mark.parametrize("kwargs,expected_indices", [
+        # Default shows all frames (< max)
+        ({}, list(range(10))),
+        # Start and end
+        ({"start": 5}, [5, 6, 7, 8, 9]),
+        ({"end": 5}, [0, 1, 2, 3, 4]),
+        # Step
+        ({"step": 2}, [0, 2, 4, 6, 8]),
+        ({"step": 3}, [0, 3, 6, 9]),
+        ({"start": 2, "end": 8, "step": 2}, [2, 4, 6]),
+        # Negative start index
+        ({"start": -1, "max": 1}, [9]),
+        ({"start": -3, "max": 2}, [7, 8]),
+        # Negative step (reverse order)
+        ({"start": 9, "step": -1}, [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
+        ({"start": 9, "end": 4, "step": -1}, [9, 8, 7, 6, 5]),
+        ({"start": 9, "step": -2}, [9, 7, 5, 3, 1]),
+        ({"start": 9, "step": -1, "max": 3}, [9, 8, 7]),
+    ])
+    def test_small_dataset(self, dataset_with_10_frames, kwargs, expected_indices):
+        fig, _ = dataset_with_10_frames.show(returnfig=True, **kwargs)
+        assert extract_frame_indices_from_figure(fig) == expected_indices
+        plt.close(fig)
+


### PR DESCRIPTION
### What this PR does

Visualize time-series, tomography, etc.

<img width="915" height="1203" alt="Screenshot 2026-01-23 at 7 57 41 AM" src="https://github.com/user-attachments/assets/dc23e3fd-bc2a-4c48-82ae-cc2f31a93c1f" />

<img width="248" height="649" alt="Screenshot 2026-01-23 at 7 57 52 AM" src="https://github.com/user-attachments/assets/ed962336-9fc9-4478-bf47-ce3177fd7eb9" />

<img width="933" height="800" alt="Screenshot 2026-01-23 at 7 57 59 AM" src="https://github.com/user-attachments/assets/2ba9afaf-d630-47e2-ae69-30233d946199" />

<img width="935" height="800" alt="Screenshot 2026-01-23 at 7 58 12 AM" src="https://github.com/user-attachments/assets/fc8f401e-a6c6-488e-88ac-8d9a3bd3a691" />

API design

```python
data.show()                          # first 20 frames (safe default)
data.show(max=None)                  # all frames
data.show(start=5, max=1)            # single frame
data.show(start=-1, max=1)           # last frame (negative indexing)
data.show(start=10, end=20)          # frames 10-19
data.show(step=5)                    # every 5th frame
data.show(start=9, step=-1)          # reverse order
data.show(ncols=2)                   # 2 columns
data.show(title_prefix="DP")         # "DP 0", "DP 1", ...
data.show(suptitle="Time Series")    # figure title
data.show(cmap="viridis", cbar=True) # colormap with colorbar
data.show(scalebar=True)             # enable scalebar
fig, axes = data.show(returnfig=True)# get figure for customization
```

Physical notebook:

[20260123_dataset3d_visual_demo_v2.ipynb](https://github.com/user-attachments/files/24824503/20260123_dataset3d_visual_demo_v2.ipynb)

Online notebook:

https://colab.research.google.com/github/bobleesj/quantem-examples/blob/main/dataset3d_visualization.ipynb

### What should PR reviewer(s) do

Please feel free to test the notebook and evaluate its API design