### PR TITLE
Hotfix config

### DIFF
--- a/src/quantem/core/config.py
+++ b/src/quantem/core/config.py
@@ -506,6 +506,8 @@ def validate_device(dev: str | int | torch.device | None = None) -> tuple[str, i
     elif isinstance(dev, str):
         if "cuda" in dev.lower():
             dev = torch.device(dev)
+        elif "gpu" in dev.lower():
+            dev = torch.device("cuda")
         elif dev.lower() == "mps":
             dev = torch.device("mps")
         elif dev.lower() == "cpu":
@@ -572,6 +574,7 @@ def set_device(dev: str | int | "torch.device") -> None:
     >>> set_device(torch.device("cuda:0"))
     >>> set_device("mps")
     >>> set_device("cpu")
+    >>> set_device("gpu")
     """
     set({"device": dev})
 

--- a/src/quantem/core/config.py
+++ b/src/quantem/core/config.py
@@ -507,7 +507,12 @@ def validate_device(dev: str | int | torch.device | None = None) -> tuple[str, i
         if "cuda" in dev.lower():
             dev = torch.device(dev)
         elif "gpu" in dev.lower():
-            dev = torch.device("cuda")
+            if torch.cuda.is_available():
+                dev = torch.device("cuda")
+            elif torch.mps.is_available():
+                dev = torch.device("mps")
+            else:
+                raise RuntimeError("gpu requested but cuda and mps are not available.")
         elif dev.lower() == "mps":
             dev = torch.device("mps")
         elif dev.lower() == "cpu":

--- a/tests/datastructures/test_autoserialize.py
+++ b/tests/datastructures/test_autoserialize.py
@@ -85,6 +85,8 @@ class subClass(AutoSerialize):
 
 
 class TestingClass(AutoSerialize):
+    __test__ = False  # tell pytest this is not a test class despite name starting with Test
+
     def __init__(self):
         self.data = np.random.rand(104, 100)
 
@@ -245,6 +247,8 @@ def test_torch_tensor_and_optimizer(tmp_path, store):
 
 
 class TestModule(torch.nn.Module, AutoSerialize):
+    __test__ = False
+
     def __init__(self):
         super().__init__()
         self.linear = torch.nn.Linear(10, 5)
@@ -270,6 +274,8 @@ def test_torch_nn_module_roundtrip(tmp_path, store):
 
 
 class TestHybrid(AutoSerialize, nn.Module):
+    __test__ = False
+
     def __init__(self):
         nn.Module.__init__(self)
         super().__init__()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ def test_config_set_device():
         assert config.get_device() == "cpu"
     else:
         with pytest.raises(RuntimeError):
-            config.set_device("gpu")
+            config.set_device("cuda:0")
 
     if torch.mps.is_available():
         config.set_device("mps")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,45 @@
+import pytest
+import torch
+
+from quantem.core import config
+
+
+def test_config_set_device():
+    config.set_device("cpu")
+    assert config.get_device() == "cpu"
+    if torch.cuda.is_available():
+        config.set_device("gpu")
+        assert config.get_device() == "cuda:0"
+        config.set_device("GPU")
+        assert config.get_device() == "cuda:0"
+        config.set_device(0)
+        assert config.get_device() == "cuda:0"
+        NUM_DEVICES = torch.cuda.device_count()
+        if NUM_DEVICES > 0:
+            config.set_device(NUM_DEVICES - 1)
+            assert config.get_device() == f"cuda:{NUM_DEVICES - 1}"
+        config.refresh()
+        assert config.get_device() == "cpu"
+    else:
+        with pytest.raises(RuntimeError):
+            config.set_device("gpu")
+
+    if torch.mps.is_available():
+        config.set_device("mps")
+        assert config.get_device() == "mps"
+    else:
+        with pytest.raises(RuntimeError):
+            config.set_device("mps")
+
+
+def test_config_update_defaults():
+    start_dtype = config.get("dtype_real")
+    config.set({"dtype_real": "int32"})
+    assert config.get("dtype_real") == "int32"
+    config.refresh()
+    assert config.get("dtype_real") == start_dtype
+    config.update_defaults({"dtype_real": "int32"})
+    assert config.get("dtype_real") == "int32"
+    config.refresh()
+    assert config.get("dtype_real") == "int32"
+    config.update_defaults({"dtype_real": start_dtype})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,10 @@ def test_config_set_device():
     if torch.mps.is_available():
         config.set_device("mps")
         assert config.get_device() == "mps"
+        config.set_device("gpu")
+        assert config.get_device() == "mps"
+        config.set_device("GPU")
+        assert config.get_device() == "mps"
     else:
         with pytest.raises(RuntimeError):
             config.set_device("mps")


### PR DESCRIPTION
Adding back `"gpu"` as an option for config setting device after it was accidentally removed,  and updating the tests to prevent it happening in the future. 

I also added an attribute to some of the classes in `test_autoserialize.py` as it was raising warnings. The issue was the `TestingClass` and others which were meant as classes to be used in tests, but which were trying to be ran as tests because of the name. Fixed by adding a `"__test__" = False` line as suggested [here](https://stackoverflow.com/questions/62460557/cannot-collect-test-class-testmain-because-it-has-a-init-constructor-from). 