### PR TITLE
Overhaul of vector

### DIFF
--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import dataclass
-from typing import Any, Iterable, Sequence, overload
+from typing import Any, Sequence, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -16,23 +15,13 @@ from quantem.core.utils.validators import (
 )
 
 
-@dataclass
-class _VectorState:
-    shape: tuple[int, ...]
-    data: NDArray[np.object_]
-    fields: list[str]
-    units: list[str]
-    name: str
-    metadata: dict[str, Any]
-
-
 class Vector(AutoSerialize):
     """Ragged cell data on a fixed grid.
 
-    A ``Vector`` has fixed grid dimensions (``shape``). Each fixed-grid cell stores a
-    NumPy array with shape ``(n_rows, num_fields)``. Selections always return new
-    ``Vector`` views over the same backing store, while raw NumPy extraction is explicit
-    via ``.array`` and ``.flatten()``.
+    Storage is compact and AutoSerialize-friendly:
+    - one 2D numeric row buffer for all ragged rows
+    - one start array and one length array for cell boundaries
+    - optional selection state for views
     """
 
     def __init__(
@@ -43,31 +32,40 @@ class Vector(AutoSerialize):
         name: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> None:
-        validated_shape = validate_shape(shape)
-        validated_fields = validate_fields(list(fields))
-        validated_units = validate_vector_units(list(units) if units is not None else None, len(validated_fields))
-        self._state = _VectorState(
-            shape=validated_shape,
-            data=_empty_storage(validated_shape, len(validated_fields)),
-            fields=list(validated_fields),
-            units=list(validated_units),
-            name=name or f"{len(validated_shape)}d ragged array",
-            metadata=dict(metadata or {}),
+        root_shape = validate_shape(shape)
+        root_fields = validate_fields(list(fields))
+        root_units = validate_vector_units(
+            list(units) if units is not None else None,
+            len(root_fields),
         )
-        self._coords = _root_coords(validated_shape)
-        self._field_names = tuple(validated_fields)
+
+        self._state = {
+            "shape": root_shape,
+            "fields": list(root_fields),
+            "units": list(root_units),
+            "name": name or f"{len(root_shape)}d ragged array",
+            "metadata": dict(metadata or {}),
+            "data": np.empty((0, len(root_fields)), dtype=float),
+            "cell_starts": np.zeros(_cell_count(root_shape), dtype=np.int64),
+            "cell_lengths": np.zeros(_cell_count(root_shape), dtype=np.int64),
+        }
+        self._selection_shape = root_shape
+        self._selection_indices: NDArray[np.int64] | None = None
+        self._selected_fields: tuple[str, ...] | None = None
 
     @classmethod
-    def _from_state(
+    def _from_view(
         cls,
-        state: _VectorState,
-        coords: NDArray[np.object_],
-        field_names: Sequence[str],
+        state: dict[str, Any],
+        selection_shape: tuple[int, ...],
+        selection_indices: NDArray[np.int64] | None,
+        selected_fields: tuple[str, ...] | None,
     ) -> "Vector":
         obj = cls.__new__(cls)
         obj._state = state
-        obj._coords = coords
-        obj._field_names = tuple(field_names)
+        obj._selection_shape = selection_shape
+        obj._selection_indices = None if selection_indices is None else selection_indices.astype(np.int64, copy=False)
+        obj._selected_fields = selected_fields
         return obj
 
     @classmethod
@@ -80,23 +78,18 @@ class Vector(AutoSerialize):
         name: str | None = None,
     ) -> "Vector":
         if fields is not None:
-            validated_fields = validate_fields(list(fields))
-            if num_fields is not None and len(validated_fields) != num_fields:
+            root_fields = validate_fields(list(fields))
+            if num_fields is not None and len(root_fields) != num_fields:
                 raise ValueError(
-                    f"num_fields ({num_fields}) does not match length of fields ({len(validated_fields)})"
+                    f"num_fields ({num_fields}) does not match length of fields ({len(root_fields)})"
                 )
         elif num_fields is not None:
-            validated_count = validate_num_fields(num_fields)
-            validated_fields = [f"field_{i}" for i in range(validated_count)]
+            count = validate_num_fields(num_fields)
+            root_fields = [f"field_{i}" for i in range(count)]
         else:
             raise ValueError("Must specify either 'fields' or 'num_fields'.")
 
-        return cls(
-            shape=shape,
-            fields=validated_fields,
-            units=units,
-            name=name,
-        )
+        return cls(shape=shape, fields=root_fields, units=units, name=name)
 
     @classmethod
     def from_data(
@@ -107,79 +100,80 @@ class Vector(AutoSerialize):
         units: Sequence[str] | None = None,
         name: str | None = None,
     ) -> "Vector":
-        inferred_shape, normalized_cells = _normalize_nested_data(data)
-        inferred_num_fields = normalized_cells[0].shape[1] if normalized_cells else 0
+        root_shape, cell_arrays = _normalize_nested_data(data)
+        inferred_counts = {array.shape[1] for array in cell_arrays}
+        if len(inferred_counts) > 1:
+            raise ValueError("All cell arrays must have the same number of fields.")
+        inferred_fields = cell_arrays[0].shape[1] if cell_arrays else 0
 
         if fields is not None:
-            validated_fields = validate_fields(list(fields))
-            if len(validated_fields) != inferred_num_fields:
+            root_fields = validate_fields(list(fields))
+            if len(root_fields) != inferred_fields:
                 raise ValueError(
-                    f"num_fields ({inferred_num_fields}) does not match length of fields ({len(validated_fields)})"
+                    f"num_fields ({inferred_fields}) does not match length of fields ({len(root_fields)})"
                 )
         elif num_fields is not None:
-            validated_num_fields = validate_num_fields(num_fields)
-            if validated_num_fields != inferred_num_fields:
+            count = validate_num_fields(num_fields)
+            if count != inferred_fields:
                 raise ValueError(
-                    f"Provided num_fields ({validated_num_fields}) does not match inferred ({inferred_num_fields})."
+                    f"Provided num_fields ({count}) does not match inferred ({inferred_fields})."
                 )
-            validated_fields = [f"field_{i}" for i in range(validated_num_fields)]
+            root_fields = [f"field_{i}" for i in range(count)]
         else:
-            validated_fields = [f"field_{i}" for i in range(inferred_num_fields)]
+            root_fields = [f"field_{i}" for i in range(inferred_fields)]
 
-        vector = cls(
-            shape=inferred_shape,
-            fields=validated_fields,
-            units=units,
-            name=name,
-        )
-        for coord, array in zip(np.ndindex(inferred_shape), normalized_cells):
-            vector._state.data[coord] = array.copy()
+        vector = cls(shape=root_shape, fields=root_fields, units=units, name=name)
+        vector._replace_cells(np.arange(len(cell_arrays), dtype=np.int64), cell_arrays)
         return vector
 
     @property
     def shape(self) -> tuple[int, ...]:
-        return self._coords.shape
+        return self._selection_shape
 
     @property
     def fields(self) -> list[str]:
-        return list(self._field_names)
+        if self._selected_fields is None:
+            return list(self._state["fields"])
+        return list(self._selected_fields)
 
     @property
     def units(self) -> list[str]:
-        lookup = {name: unit for name, unit in zip(self._state.fields, self._state.units)}
-        return [lookup[name] for name in self._field_names]
+        lookup = {
+            field: unit
+            for field, unit in zip(self._state["fields"], self._state["units"])
+        }
+        return [lookup[field] for field in self.fields]
 
     @property
     def num_fields(self) -> int:
-        return len(self._field_names)
+        return len(self.fields)
 
     @property
     def name(self) -> str:
-        return self._state.name
+        return self._state["name"]
 
     @name.setter
     def name(self, value: str) -> None:
-        self._state.name = str(value)
+        self._state["name"] = str(value)
 
     @property
     def metadata(self) -> dict[str, Any]:
-        return self._state.metadata
+        return self._state["metadata"]
 
     @property
     def array(self) -> NDArray[np.generic]:
         if self.shape != ():
             raise ValueError(".array is only valid when the selection contains exactly one cell.")
-        coord = self._coords[()]
-        cell = self._state.data[coord]
-        indices = self._field_indices()
-        if len(indices) == len(self._state.fields) and indices == list(range(len(self._state.fields))):
+        cell = self._cell_matrix(self._selected_cell_indices()[0])
+        cols = self._field_indices()
+        if cols.size == self._full_num_fields:
             return cell
-        if len(indices) == 1:
-            idx = indices[0]
-            return cell[:, idx : idx + 1]
-        if _is_contiguous(indices):
-            return cell[:, indices[0] : indices[-1] + 1]
-        return cell[:, indices].copy()
+        if cols.size == 1:
+            col = int(cols[0])
+            return cell[:, col : col + 1]
+        if _is_contiguous(cols):
+            return cell[:, int(cols[0]) : int(cols[-1]) + 1]
+        return cell[:, cols].copy()
 
     def __len__(self) -> int:
         if self.shape == ():
@@ -187,44 +181,58 @@ class Vector(AutoSerialize):
         return self.shape[0]
 
     def __repr__(self) -> str:
-        return f"quantem.Vector(shape={self.shape}, fields={self.fields}, name={self.name!r})"
+        return "\n".join(
+            [
+                f"quantem.Vector, shape={self.shape}, name={self.name}",
+                f"  fields = {self.fields}",
+                f"  units: {self.units}",
+            ]
+        )
 
     __str__ = __repr__
 
     def copy(self) -> "Vector":
-        copied = self.__class__._from_state(
-            _VectorState(
-                shape=self.shape,
-                data=_empty_storage(self.shape, self.num_fields),
-                fields=self.fields,
-                units=self.units,
-                name=self.name,
-                metadata=copy.deepcopy(self.metadata),
-            ),
-            _root_coords_allow_empty(self.shape),
-            self.fields,
+        copied = self.__class__(
+            shape=self.shape,
+            fields=self.fields,
+            units=self.units,
+            name=self.name,
+            metadata=copy.deepcopy(self.metadata),
         )
-        for coord, array in zip(np.ndindex(self.shape) if self.shape != () else [()], self._iter_selected_arrays()):
-            copied._state.data[coord] = array.copy()
+        target_cells = copied._selected_cell_indices()
+        source_arrays = [self._selected_cell_matrix(index).copy() for index in self._selected_cell_indices()]
+        copied._replace_cells(target_cells, source_arrays)
         return copied
 
     def flatten(self) -> NDArray[np.generic]:
-        arrays = [array for array in self._iter_selected_arrays() if array.shape[0] > 0]
+        arrays = [
+            self._selected_cell_matrix(index)
+            for index in self._selected_cell_indices()
+            if self._cell_row_count(index) > 0
+        ]
         if arrays:
             return np.vstack(arrays)
-        dtype = float
-        for array in self._iter_selected_arrays():
-            dtype = array.dtype
-            break
+
+        dtype = self._state["data"].dtype if self._state["data"].ndim == 2 else float
         return np.empty((0, self.num_fields), dtype=dtype)
 
     def select_fields(self, field_names: str | Sequence[str]) -> "Vector":
-        normalized = _normalize_field_names(field_names)
-        available = set(self._field_names)
-        missing = [name for name in normalized if name not in available]
+        selected = _normalize_field_names(field_names)
+        available = set(self.fields)
+        missing = [field for field in selected if field not in available]
         if missing:
             raise KeyError(f"Unknown field(s): {missing}")
-        return self._from_state(self._state, self._coords, normalized)
+
+        if selected == tuple(self._state["fields"]):
+            selected_fields = None
+        else:
+            selected_fields = selected
+        return self._from_view(
+            self._state,
+            self.shape,
+            self._selection_indices,
+            selected_fields,
+        )
 
     def add_fields(
         self,
@@ -232,56 +240,49 @@ class Vector(AutoSerialize):
         values: Any | None = None,
         units: str | Sequence[str] | None = None,
     ) -> None:
-        new_names = _normalize_field_names(names)
-        if any(name in self._state.fields for name in new_names):
+        new_fields = _normalize_field_names(names)
+        if any(field in self._state["fields"] for field in new_fields):
             raise ValueError("One or more new field names already exist.")
 
-        new_units = _normalize_units(units, len(new_names))
-        old_fields = list(self._state.fields)
-        self._state.fields.extend(new_names)
-        self._state.units.extend(new_units)
+        new_units = _normalize_units(units, len(new_fields))
+        old_fields = list(self._state["fields"])
+        self._state["fields"].extend(new_fields)
+        self._state["units"].extend(new_units)
+        self._expand_storage(len(new_fields))
 
-        old_width = len(old_fields)
-        new_width = len(self._state.fields)
-        for coord in np.ndindex(self._state.shape) if self._state.shape != () else [()]:
-            current = self._state.data[coord]
-            promoted = np.result_type(current.dtype, float)
-            expanded = np.full((current.shape[0], new_width), np.nan, dtype=promoted)
-            expanded[:, :old_width] = current
-            self._state.data[coord] = expanded
-
-        if list(self._field_names) == old_fields:
-            self._field_names = tuple(self._state.fields)
-
-        target = self._from_state(self._state, self._coords, new_names)
         if values is None:
             return
 
-        if len(new_names) > 1 and isinstance(values, (list, tuple)) and len(values) == len(new_names):
-            for name, value in zip(new_names, values):
-                target.select_fields(name)._assign(value)
+        target = self.select_fields(list(new_fields))
+        if len(new_fields) > 1 and isinstance(values, (list, tuple)) and len(values) == len(new_fields):
+            for field, value in zip(new_fields, values):
+                target.select_fields(field)[...] = value
         else:
-            target._assign(values)
+            target[...] = values
+
+        if self._selected_fields is not None and tuple(old_fields) == self._selected_fields:
+            self._selected_fields = None
 
     def remove_fields(self, names: str | Sequence[str]) -> None:
-        to_remove = _normalize_field_names(names)
-        missing = [name for name in to_remove if name not in self._state.fields]
+        to_remove = set(_normalize_field_names(names))
+        old_fields = self._state["fields"]
+        old_units = self._state["units"]
+
+        missing = [field for field in to_remove if field not in old_fields]
         if missing:
             raise KeyError(f"Unknown field(s): {missing}")
-        if len(to_remove) == len(self._state.fields):
+        if len(to_remove) == len(old_fields):
             raise ValueError("Cannot remove all fields from a Vector.")
 
-        remove_set = set(to_remove)
-        keep_names = [name for name in self._state.fields if name not in remove_set]
-        keep_indices = [self._state.fields.index(name) for name in keep_names]
-        keep_units = [self._state.units[index] for index in keep_indices]
+        keep = [i for i, field in enumerate(old_fields) if field not in to_remove]
+        self._state["fields"] = [old_fields[i] for i in keep]
+        self._state["units"] = [old_units[i] for i in keep]
+        self._state["data"] = self._state["data"][:, keep]
 
-        for coord in np.ndindex(self._state.shape) if self._state.shape != () else [()]:
-            self._state.data[coord] = self._state.data[coord][:, keep_indices]
-
-        self._state.fields = keep_names
-        self._state.units = keep_units
-        self._field_names = tuple(name for name in self._field_names if name in keep_names)
+        if self._selected_fields is not None:
+            self._selected_fields = tuple(field for field in self._selected_fields if field in self._state["fields"])
+            if len(self._selected_fields) == len(self._state["fields"]):
+                self._selected_fields = None
 
     def get_data(self, *indices: Any) -> NDArray[np.generic] | list[NDArray[np.generic]]:
         if len(indices) != len(self.shape):
@@ -289,7 +290,7 @@ class Vector(AutoSerialize):
         selection = self[indices if len(indices) != 1 else indices[0]]
         if selection.shape == ():
             return selection.array
-        return [array.copy() for array in selection._iter_selected_arrays()]
+        return [selection._selected_cell_matrix(index).copy() for index in selection._selected_cell_indices()]
 
     def set_data(self, value: Any, *indices: Any) -> None:
         if len(indices) != len(self.shape):
@@ -300,15 +301,29 @@ class Vector(AutoSerialize):
     def __getitem__(self, idx: Any) -> "Vector": ...
 
     def __getitem__(self, idx: Any) -> "Vector":
-        if _is_field_selector(idx):
+        if _looks_like_field_selector(idx):
             raise TypeError("Use select_fields(...) for field selection.")
-        coords = _select_coords(self._coords, idx)
-        return self._from_state(self._state, coords, self._field_names)
+        if idx is Ellipsis:
+            return self
+
+        selection_shape, selection_indices = _select_linear_indices(
+            self.shape,
+            self._selected_cell_indices(),
+            idx,
+        )
+        return self._from_view(
+            self._state,
+            selection_shape,
+            selection_indices,
+            self._selected_fields,
+        )
 
     def __setitem__(self, idx: Any, value: Any) -> None:
-        if _is_field_selector(idx):
-            raise TypeError("Use select_fields(...) for field selection.")
-        self[idx]._assign(value)
+        if idx is Ellipsis:
+            target = self
+        else:
+            target = self[idx]
+        target._assign(value)
 
     def __add__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.add)
@@ -322,51 +337,137 @@ class Vector(AutoSerialize):
     def __truediv__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.divide)
 
-    def __pow__(self, other: Any) -> "Vector":
-        return self._binary_op(other, np.power)
+    def __radd__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.add, reverse=True)
+
+    def __rmul__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.multiply, reverse=True)
+
+    def __rsub__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.subtract, reverse=True)
+
+    def __rtruediv__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.divide, reverse=True)
 
     def __iadd__(self, other: Any) -> "Vector":
-        return self._binary_op_inplace(other, np.add)
+        self._inplace_op(other, np.add)
+        return self
 
     def __isub__(self, other: Any) -> "Vector":
-        return self._binary_op_inplace(other, np.subtract)
+        self._inplace_op(other, np.subtract)
+        return self
 
     def __imul__(self, other: Any) -> "Vector":
-        return self._binary_op_inplace(other, np.multiply)
+        self._inplace_op(other, np.multiply)
+        return self
 
     def __itruediv__(self, other: Any) -> "Vector":
-        return self._binary_op_inplace(other, np.divide)
-
-    def __ipow__(self, other: Any) -> "Vector":
-        return self._binary_op_inplace(other, np.power)
-
-    def _binary_op(self, other: Any, op: Any) -> "Vector":
-        result = self.copy()
-        result._binary_op_inplace(other, op)
-        return result
-
-    def _binary_op_inplace(self, other: Any, op: Any) -> "Vector":
-        row_counts = self._row_counts()
-        targets = list(self._iter_coords())
-
-        if isinstance(other, Vector):
-            self._validate_vector_rhs(other, require_matching_rows=True)
-            source_arrays = list(other._iter_selected_arrays())
-            for coord, current, rhs in zip(targets, self._iter_selected_arrays(), source_arrays):
-                updated = current.copy()
-                op(updated, rhs, out=updated, casting="same_kind")
-                self._write_selected_array(coord, updated)
-            return self
-
-        rhs_matrix = _broadcast_rhs(np.asarray(other), sum(row_counts), self.num_fields)
-        cursor = 0
-        for coord, current, row_count in zip(targets, self._iter_selected_arrays(), row_counts):
-            chunk = rhs_matrix[cursor : cursor + row_count]
-            cursor += row_count
-            updated = current.copy()
-            op(updated, chunk, out=updated, casting="same_kind")
-            self._write_selected_array(coord, updated)
+        self._inplace_op(other, np.divide)
         return self
+
+    @property
+    def _full_num_fields(self) -> int:
+        return len(self._state["fields"])
+
+    def _field_indices(self) -> NDArray[np.int64]:
+        if self._selected_fields is None:
+            return np.arange(self._full_num_fields, dtype=np.int64)
+
+        lookup = {field: i for i, field in enumerate(self._state["fields"])}
+        try:
+            return np.array([lookup[field] for field in self._selected_fields], dtype=np.int64)
+        except KeyError as exc:
+            raise KeyError(f"Unknown field(s): {[str(exc.args[0])]}") from exc
+
+    def _selected_cell_indices(self) -> NDArray[np.int64]:
+        if self._selection_indices is None:
+            return np.arange(_cell_count(self._state["shape"]), dtype=np.int64)
+        return self._selection_indices
+
+    def _is_full_field_selection(self) -> bool:
+        return self._selected_fields is None
+
+    def _cell_row_count(self, linear_index: int) -> int:
+        return int(self._state["cell_lengths"][linear_index])
+
+    def _cell_matrix(self, linear_index: int) -> NDArray[np.generic]:
+        start = int(self._state["cell_starts"][linear_index])
+        length = int(self._state["cell_lengths"][linear_index])
+        if length == 0:
+            return self._state["data"][0:0]
+        return self._state["data"][start : start + length]
+
+    def _selected_cell_matrix(self, linear_index: int) -> NDArray[np.generic]:
+        cell = self._cell_matrix(linear_index)
+        cols = self._field_indices()
+        if cols.size == self._full_num_fields:
+            return cell
+        if cols.size == 1:
+            col = int(cols[0])
+            return cell[:, col : col + 1]
+        if _is_contiguous(cols):
+            return cell[:, int(cols[0]) : int(cols[-1]) + 1]
+        return cell[:, cols].copy()
+
+    def _replace_cells(self, targets: NDArray[np.int64], arrays: Sequence[NDArray[np.generic]]) -> None:
+        if len(targets) != len(arrays):
+            raise ValueError("Target cell count does not match source cell count.")
+        if len(targets) == 0:
+            return
+
+        normalized = [_coerce_cell_array(array, self._full_num_fields) for array in arrays]
+        payloads = [array for array in normalized if array.shape[0] > 0]
+        if payloads:
+            appended = np.vstack(payloads)
+            data = self._state["data"]
+            if data.shape[0] == 0:
+                self._state["data"] = appended.copy()
+            else:
+                self._state["data"] = np.concatenate((data, appended), axis=0)
+
+        cursor = self._state["data"].shape[0] - sum(array.shape[0] for array in normalized)
+        for target, array in zip(targets, normalized):
+            self._state["cell_starts"][target] = cursor
+            self._state["cell_lengths"][target] = array.shape[0]
+            cursor += array.shape[0]
+
+        self._maybe_compact_storage()
+
+    def _expand_storage(self, num_new_fields: int) -> None:
+        data = self._state["data"]
+        if data.shape[0] == 0:
+            dtype = np.result_type(data.dtype, float)
+            self._state["data"] = np.empty((0, data.shape[1] + num_new_fields), dtype=dtype)
+            return
+
+        dtype = np.result_type(data.dtype, float)
+        filler = np.full((data.shape[0], num_new_fields), np.nan, dtype=dtype)
+        self._state["data"] = np.concatenate((data.astype(dtype, copy=False), filler), axis=1)
+
+    def _maybe_compact_storage(self) -> None:
+        data = self._state["data"]
+        used_rows = int(self._state["cell_lengths"].sum())
+        if data.shape[0] <= used_rows + 1024:
+            return
+        if used_rows == 0:
+            self._state["data"] = np.empty((0, self._full_num_fields), dtype=data.dtype)
+            self._state["cell_starts"].fill(0)
+            return
+        if data.shape[0] <= 2 * used_rows:
+            return
+
+        compacted = np.empty((used_rows, self._full_num_fields), dtype=data.dtype)
+        starts = np.zeros_like(self._state["cell_starts"])
+        cursor = 0
+        for linear_index in range(_cell_count(self._state["shape"])):
+            length = self._cell_row_count(linear_index)
+            starts[linear_index] = cursor
+            if length > 0:
+                cell = self._cell_matrix(linear_index)
+                compacted[cursor : cursor + length] = cell
+                cursor += length
+        self._state["data"] = compacted
+        self._state["cell_starts"] = starts
 
     def _assign(self, value: Any) -> None:
         if self._is_full_field_selection():
@@ -375,131 +476,122 @@ class Vector(AutoSerialize):
             self._assign_selected_fields(value)
 
     def _assign_full_cells(self, value: Any) -> None:
-        targets = list(self._iter_coords())
+        targets = self._selected_cell_indices()
         if isinstance(value, Vector):
-            self._validate_vector_rhs(value, require_matching_rows=False)
-            for target, source in zip(targets, value._iter_selected_arrays()):
-                self._state.data[target] = source.copy()
+            source_cells = value._selected_cell_indices()
+            if len(targets) != len(source_cells):
+                raise ValueError(f"Expected {len(targets)} cells, got {len(source_cells)}")
+            if value.num_fields != self.num_fields:
+                raise ValueError(
+                    f"Expected {self.num_fields} fields, got {value.num_fields}"
+                )
+            arrays = [value._selected_cell_matrix(index).copy() for index in source_cells]
+            self._replace_cells(targets, arrays)
             return
 
         array = _coerce_cell_array(value, self.num_fields)
-        for target in targets:
-            self._state.data[target] = array.copy()
+        self._replace_cells(targets, [array] * len(targets))
 
     def _assign_selected_fields(self, value: Any) -> None:
-        targets = list(self._iter_coords())
-        row_counts = self._row_counts()
+        targets = self._selected_cell_indices()
+        field_indices = self._field_indices()
+        row_counts = [self._cell_row_count(index) for index in targets]
+        total_rows = sum(row_counts)
+
         if isinstance(value, Vector):
-            self._validate_vector_rhs(value, require_matching_rows=True)
-            for coord, source in zip(targets, value._iter_selected_arrays()):
-                self._write_selected_array(coord, source)
+            source_cells = value._selected_cell_indices()
+            if len(targets) != len(source_cells):
+                raise ValueError(f"Expected {len(targets)} cells, got {len(source_cells)}")
+            if value.num_fields != self.num_fields:
+                raise ValueError(
+                    f"Expected {self.num_fields} fields, got {value.num_fields}"
+                )
+            source_counts = [value._cell_row_count(index) for index in source_cells]
+            if row_counts != source_counts:
+                raise ValueError("Per-cell row counts must match for field-selected assignment.")
+            snapshots = [value._selected_cell_matrix(index).copy() for index in source_cells]
+            for target, array in zip(targets, snapshots):
+                cell = self._cell_matrix(int(target))
+                if array.shape[0] > 0:
+                    cell[:, field_indices] = array
             return
 
         if np.isscalar(value):
-            for coord in targets:
-                current = self._selected_array_for_coord(coord)
-                fill = np.full(current.shape, value)
-                self._write_selected_array(coord, fill)
+            for target in targets:
+                cell = self._cell_matrix(int(target))
+                if cell.shape[0] > 0:
+                    cell[:, field_indices] = value
             return
 
-        rhs_matrix = _broadcast_rhs(np.asarray(value), sum(row_counts), self.num_fields)
+        broadcast = _broadcast_field_values(value, total_rows, self.num_fields)
         cursor = 0
-        for coord, row_count in zip(targets, row_counts):
-            chunk = rhs_matrix[cursor : cursor + row_count]
-            cursor += row_count
-            self._write_selected_array(coord, chunk)
+        for target, rows in zip(targets, row_counts):
+            chunk = broadcast[cursor : cursor + rows]
+            cell = self._cell_matrix(int(target))
+            if rows > 0:
+                cell[:, field_indices] = chunk
+            cursor += rows
 
-    def _validate_vector_rhs(self, other: "Vector", require_matching_rows: bool) -> None:
-        if self.num_fields != other.num_fields:
-            raise ValueError(f"Expected {self.num_fields} fields, got {other.num_fields}")
-        if self._coords.size != other._coords.size:
-            raise ValueError(f"Expected {self._coords.size} cells, got {other._coords.size}")
-        if require_matching_rows:
-            left = self._row_counts()
-            right = other._row_counts()
-            if left != right:
-                raise ValueError(f"Per-cell row counts must match: {left} != {right}")
+    def _binary_op(self, other: Any, op: Any, reverse: bool = False) -> "Vector":
+        result = self.copy()
+        result._inplace_op(other, op, reverse=reverse)
+        return result
 
-    def _row_counts(self) -> list[int]:
-        return [self._state.data[coord].shape[0] for coord in self._iter_coords()]
+    def _inplace_op(self, other: Any, op: Any, reverse: bool = False) -> None:
+        targets = self._selected_cell_indices()
+        field_indices = self._field_indices()
+        row_counts = [self._cell_row_count(index) for index in targets]
+        total_rows = sum(row_counts)
 
-    def _iter_coords(self) -> Iterable[tuple[int, ...]]:
-        return iter(self._coords.flat)
-
-    def _iter_selected_arrays(self) -> Iterable[NDArray[np.generic]]:
-        for coord in self._iter_coords():
-            yield self._selected_array_for_coord(coord)
-
-    def _selected_array_for_coord(self, coord: tuple[int, ...]) -> NDArray[np.generic]:
-        cell = self._state.data[coord]
-        indices = self._field_indices()
-        if self._is_full_field_selection():
-            return cell
-        if len(indices) == 1:
-            idx = indices[0]
-            return cell[:, idx : idx + 1]
-        if _is_contiguous(indices):
-            return cell[:, indices[0] : indices[-1] + 1]
-        return cell[:, indices].copy()
-
-    def _write_selected_array(self, coord: tuple[int, ...], values: NDArray[np.generic]) -> None:
-        cell = self._state.data[coord]
-        if self._is_full_field_selection():
-            replacement = _coerce_cell_array(values, self.num_fields)
-            self._state.data[coord] = replacement.copy()
+        if isinstance(other, Vector):
+            source_cells = other._selected_cell_indices()
+            if len(targets) != len(source_cells):
+                raise ValueError(f"Expected {len(targets)} cells, got {len(source_cells)}")
+            if other.num_fields != self.num_fields:
+                raise ValueError(f"Expected {self.num_fields} fields, got {other.num_fields}")
+            source_counts = [other._cell_row_count(index) for index in source_cells]
+            if row_counts != source_counts:
+                raise ValueError("Per-cell row counts must match for Vector arithmetic.")
+            snapshots = [other._selected_cell_matrix(index).copy() for index in source_cells]
+            for target, rhs in zip(targets, snapshots):
+                cell = self._cell_matrix(int(target))
+                lhs = cell[:, field_indices]
+                cell[:, field_indices] = op(rhs, lhs) if reverse else op(lhs, rhs)
             return
 
-        if values.ndim != 2 or values.shape[1] != self.num_fields:
-            raise ValueError(
-                f"Expected array with shape (_, {self.num_fields}), got {values.shape}"
-            )
-        if values.shape[0] != cell.shape[0]:
-            raise ValueError(
-                f"Expected {cell.shape[0]} rows for in-place field update, got {values.shape[0]}"
-            )
-        cell[:, self._field_indices()] = values
+        if np.isscalar(other):
+            for target in targets:
+                cell = self._cell_matrix(int(target))
+                lhs = cell[:, field_indices]
+                if lhs.shape[0] > 0:
+                    cell[:, field_indices] = op(other, lhs) if reverse else op(lhs, other)
+            return
 
-    def _field_indices(self) -> list[int]:
-        lookup = {name: idx for idx, name in enumerate(self._state.fields)}
-        try:
-            return [lookup[name] for name in self._field_names]
-        except KeyError as exc:
-            raise KeyError(f"Unknown field '{exc.args[0]}'") from exc
-
-    def _is_full_field_selection(self) -> bool:
-        return list(self._field_names) == self._state.fields
+        broadcast = _broadcast_field_values(other, total_rows, self.num_fields)
+        cursor = 0
+        for target, rows in zip(targets, row_counts):
+            chunk = broadcast[cursor : cursor + rows]
+            cell = self._cell_matrix(int(target))
+            lhs = cell[:, field_indices]
+            if rows > 0:
+                cell[:, field_indices] = op(chunk, lhs) if reverse else op(lhs, chunk)
+            cursor += rows
 
 
-def _empty_storage(shape: tuple[int, ...], num_fields: int) -> NDArray[np.object_]:
-    storage = np.empty(shape if shape != () else (), dtype=object)
-    for coord in np.ndindex(shape) if shape != () else [()]:
-        storage[coord] = np.empty((0, num_fields), dtype=float)
-    return storage
+def _cell_count(shape: tuple[int, ...]) -> int:
+    return int(np.prod(shape, dtype=np.int64)) if shape else 1
 
 
-def _root_coords(shape: tuple[int, ...]) -> NDArray[np.object_]:
-    return _root_coords_allow_empty(shape)
-
-
-def _root_coords_allow_empty(shape: tuple[int, ...]) -> NDArray[np.object_]:
-    coords = np.empty(shape if shape != () else (), dtype=object)
-    for coord in np.ndindex(shape) if shape != () else [()]:
-        coords[coord] = coord
-    return coords
-
-
-def _normalize_field_names(field_names: str | Sequence[str]) -> list[str]:
+def _normalize_field_names(field_names: str | Sequence[str]) -> tuple[str, ...]:
     if isinstance(field_names, str):
-        names = [field_names]
-    elif isinstance(field_names, Sequence):
-        names = [str(name) for name in field_names]
+        normalized = (field_names,)
     else:
-        raise TypeError("Field names must be a string or a sequence of strings.")
-    if not names:
-        raise ValueError("Must select at least one field.")
-    if len(set(names)) != len(names):
-        raise ValueError("Duplicate field names are not allowed.")
-    return names
+        normalized = tuple(field_names)
+    if not normalized:
+        raise ValueError("At least one field name is required.")
+    validate_fields(list(normalized))
+    return normalized
+
 
 
 def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]:
@@ -507,188 +599,234 @@ def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]
         return ["none"] * count
     if isinstance(units, str):
         if count != 1:
-            raise ValueError("A single unit string is only valid for a single new field.")
+            raise ValueError("A single unit can only be provided for a single field.")
         return [units]
-    normalized = [str(unit) for unit in units]
+    normalized = list(units)
     if len(normalized) != count:
         raise ValueError(f"Expected {count} units, got {len(normalized)}")
     return normalized
 
 
-def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
-    array = np.asarray(value)
-    if array.ndim != 2 or array.shape[1] != num_fields:
-        raise ValueError(f"Expected a numpy array with shape (_, {num_fields}), got {array.shape}")
-    if not np.issubdtype(array.dtype, np.number):
-        raise TypeError("Cell arrays must contain numeric values.")
-    return array
 
-
-def _broadcast_rhs(value: NDArray[np.generic], total_rows: int, num_fields: int) -> NDArray[np.generic]:
-    if num_fields == 1 and value.ndim == 1:
-        value = value.reshape(-1, 1)
-    try:
-        return np.broadcast_to(value, (total_rows, num_fields))
-    except ValueError as exc:
-        raise ValueError(
-            f"RHS is not broadcast-compatible with flattened target shape ({total_rows}, {num_fields})."
-        ) from exc
-
-
-def _is_field_selector(idx: Any) -> bool:
+def _looks_like_field_selector(idx: Any) -> bool:
     if isinstance(idx, str):
         return True
-    if isinstance(idx, list | tuple) and idx:
-        if all(isinstance(item, str) for item in idx):
-            return True
-        return any(isinstance(item, str) for item in idx)
+    if isinstance(idx, tuple) and any(_looks_like_field_selector(item) for item in idx):
+        return True
+    if isinstance(idx, (list, tuple)) and idx and all(isinstance(item, str) for item in idx):
+        return True
     return False
 
 
-def _is_contiguous(indices: Sequence[int]) -> bool:
-    if not indices:
-        return False
-    return list(indices) == list(range(indices[0], indices[0] + len(indices)))
 
+def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
+    if isinstance(value, Vector):
+        if value.shape != ():
+            raise ValueError("Expected a 0D Vector for single-cell assignment.")
+        array = value.array.copy()
+    else:
+        array = np.asarray(value)
 
-def _select_coords(coords: NDArray[np.object_], idx: Any) -> NDArray[np.object_]:
-    shape = coords.shape
-    selectors, scalar_axes = _normalize_indices(shape, idx)
-    out_shape = tuple(len(selector) for selector, scalar in zip(selectors, scalar_axes) if not scalar)
-    result = np.empty(out_shape if out_shape != () else (), dtype=object)
+    if array.ndim == 0:
+        raise ValueError("Cell assignment requires a 2D array.")
+    if array.ndim == 1:
+        if array.size == 0:
+            array = np.empty((0, num_fields), dtype=float)
+        elif num_fields == 1:
+            array = array.reshape(-1, 1)
+        else:
+            array = array.reshape(1, -1)
+    if array.ndim != 2:
+        raise ValueError("Cell assignment requires a 2D array.")
+    if array.shape[1] != num_fields:
+        raise ValueError(f"Expected {num_fields} fields, got {array.shape[1]}")
+    return array
 
-    if out_shape == ():
-        source = tuple(selector[0] for selector in selectors)
-        result[()] = coords[source]
-        return result
-
-    for out_index in np.ndindex(out_shape):
-        out_cursor = 0
-        source = []
-        for axis, selector in enumerate(selectors):
-            if scalar_axes[axis]:
-                source.append(selector[0])
-            else:
-                source.append(selector[out_index[out_cursor]])
-                out_cursor += 1
-        result[out_index] = coords[tuple(source)]
-    return result
-
-
-def _normalize_indices(shape: tuple[int, ...], idx: Any) -> tuple[list[np.ndarray], list[bool]]:
-    if shape == ():
-        if idx in ((), Ellipsis, slice(None), None):
-            return [], []
-        raise IndexError("Too many indices for a 0D Vector.")
-
-    normalized = idx if isinstance(idx, tuple) else (idx,)
-    normalized = _expand_ellipsis(normalized, len(shape))
-    if len(normalized) > len(shape):
-        raise IndexError(f"Expected at most {len(shape)} indices, got {len(normalized)}")
-    normalized = normalized + (slice(None),) * (len(shape) - len(normalized))
-
-    selectors: list[np.ndarray] = []
-    scalar_axes: list[bool] = []
-    for axis_value, axis_size in zip(normalized, shape):
-        selector, scalar = _normalize_axis_index(axis_value, axis_size)
-        selectors.append(selector)
-        scalar_axes.append(scalar)
-    return selectors, scalar_axes
-
-
-def _expand_ellipsis(idx: tuple[Any, ...], ndim: int) -> tuple[Any, ...]:
-    if not any(item is Ellipsis for item in idx):
-        return idx
-    if sum(item is Ellipsis for item in idx) > 1:
-        raise IndexError("Only one ellipsis is allowed.")
-    ellipsis_pos = next(i for i, item in enumerate(idx) if item is Ellipsis)
-    fill = ndim - (len(idx) - 1)
-    return idx[:ellipsis_pos] + (slice(None),) * fill + idx[ellipsis_pos + 1 :]
-
-
-def _normalize_axis_index(value: Any, axis_size: int) -> tuple[np.ndarray, bool]:
-    if isinstance(value, (int, np.integer)):
-        index = int(value)
-        if index < 0:
-            index += axis_size
-        if index < 0 or index >= axis_size:
-            raise IndexError(f"Index {value} out of bounds for axis with size {axis_size}")
-        return np.array([index], dtype=int), True
-
-    if isinstance(value, slice):
-        return np.arange(axis_size)[value], False
-
-    if isinstance(value, np.ndarray) and value.ndim == 0:
-        return _normalize_axis_index(value.item(), axis_size)
-
-    array = np.asarray(value)
-    if array.ndim != 1:
-        raise IndexError("Only 1D per-axis fancy or boolean indexing is supported.")
-    if array.size == 0:
-        return np.array([], dtype=int), False
-
-    if array.dtype == bool or np.issubdtype(array.dtype, np.bool_):
-        if array.shape[0] != axis_size:
-            raise IndexError(
-                f"Boolean mask length {array.shape[0]} does not match axis size {axis_size}"
-            )
-        return np.flatnonzero(array), False
-
-    if not np.issubdtype(array.dtype, np.integer):
-        raise TypeError(f"Unsupported index type {type(value).__name__}")
-
-    normalized = array.astype(int, copy=True)
-    normalized[normalized < 0] += axis_size
-    if np.any((normalized < 0) | (normalized >= axis_size)):
-        raise IndexError(f"Index out of bounds for axis with size {axis_size}")
-    return normalized, False
 
 
 def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
     if not isinstance(data, list):
-        raise TypeError("Data must be a list.")
+        raise TypeError("Data must be a list")
     if not data:
-        raise ValueError("Data list cannot be empty.")
-
-    leaves: list[NDArray[np.generic]] = []
-    num_fields: int | None = None
-
-    def walk(node: Any) -> tuple[int, ...]:
-        nonlocal num_fields
-        if _is_leaf_cell(node):
-            array = np.asarray(node)
-            if array.ndim != 2:
-                raise ValueError(f"Cell arrays must be 2D, got shape {array.shape}")
-            if not np.issubdtype(array.dtype, np.number):
-                raise TypeError("Cell arrays must contain numeric values.")
-            if num_fields is None:
-                num_fields = array.shape[1]
-            elif array.shape[1] != num_fields:
-                raise ValueError("All data arrays must have same number of fields.")
-            leaves.append(array)
-            return ()
-
-        if not isinstance(node, list):
-            raise TypeError("Data elements must be numpy arrays, numeric 2D lists, or nested lists thereof.")
-        if not node:
-            raise ValueError("Nested data lists cannot be empty.")
-        child_shapes = [walk(child) for child in node]
-        first = child_shapes[0]
-        if any(shape != first for shape in child_shapes[1:]):
-            raise ValueError("Nested data structure must have a consistent fixed-grid shape.")
-        return (len(node), *first)
-
-    inferred_shape = walk(data)
-    return inferred_shape, leaves
+        return (0,), []
+    return _flatten_fixed_grid(data)
 
 
-def _is_leaf_cell(node: Any) -> bool:
+
+def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
     if isinstance(node, np.ndarray):
+        return (), [_coerce_inferred_cell_array(node)]
+    if not isinstance(node, (list, tuple)):
+        raise TypeError("Data must be a nested list/tuple of cell arrays or row sequences.")
+    if _looks_like_cell_rows(node):
+        return (), [_coerce_inferred_cell_array(node)]
+    if len(node) == 0:
+        return (0,), []
+
+    child_shape: tuple[int, ...] | None = None
+    cells: list[NDArray[np.generic]] = []
+    for child in node:
+        shape, child_cells = _flatten_fixed_grid(child)
+        if child_shape is None:
+            child_shape = shape
+        elif child_shape != shape:
+            raise ValueError("All nested fixed-grid branches must have matching shapes.")
+        cells.extend(child_cells)
+
+    assert child_shape is not None
+    return (len(node),) + child_shape, cells
+
+
+
+def _looks_like_cell_rows(node: Sequence[Any]) -> bool:
+    if len(node) == 0:
         return True
-    if not isinstance(node, list):
+    return all(_is_row_like(item) for item in node)
+
+
+
+def _is_row_like(item: Any) -> bool:
+    if isinstance(item, np.ndarray):
+        return item.ndim == 1
+    if not isinstance(item, (list, tuple)):
         return False
+    return all(np.isscalar(value) for value in item)
+
+
+
+def _coerce_inferred_cell_array(value: Any) -> NDArray[np.generic]:
+    array = np.asarray(value)
+    if array.ndim == 0:
+        raise ValueError("Cell data must be 1D or 2D.")
+    if array.ndim == 1:
+        if array.size == 0:
+            return np.empty((0, 0), dtype=float)
+        return array.reshape(1, -1)
+    if array.ndim != 2:
+        raise ValueError("Cell data must be 1D or 2D.")
+    return array
+
+
+
+def _select_linear_indices(
+    shape: tuple[int, ...],
+    current_indices: NDArray[np.int64],
+    idx: Any,
+) -> tuple[tuple[int, ...], NDArray[np.int64]]:
+    if shape == ():
+        if idx in ((), Ellipsis):
+            return (), np.array([int(current_indices[0])], dtype=np.int64)
+        raise IndexError("Too many indices for 0D Vector")
+
+    index_tuple = _normalize_index_tuple(idx, len(shape))
+    current_grid = current_indices.reshape(shape)
+
+    axis_positions: list[NDArray[np.int64]] = []
+    out_shape: list[int] = []
+    scalar_axes: list[bool] = []
+    for axis, axis_index in enumerate(index_tuple):
+        positions, is_scalar = _positions_for_axis(axis_index, shape[axis])
+        axis_positions.append(positions)
+        scalar_axes.append(is_scalar)
+        if not is_scalar:
+            out_shape.append(len(positions))
+
+    if all(scalar_axes):
+        scalar_key = tuple(int(positions[0]) for positions in axis_positions)
+        value = int(current_grid[scalar_key])
+        return (), np.array([value], dtype=np.int64)
+
+    mesh_inputs = [positions if not is_scalar else positions[:1] for positions, is_scalar in zip(axis_positions, scalar_axes)]
+    grids = np.meshgrid(*mesh_inputs, indexing="ij")
+    selected = np.asarray(current_grid[tuple(grids)], dtype=np.int64).reshape(-1)
+    return tuple(out_shape), selected
+
+
+
+def _normalize_index_tuple(idx: Any, ndim: int) -> tuple[Any, ...]:
+    if idx is Ellipsis:
+        return (slice(None),) * ndim
+    if not isinstance(idx, tuple):
+        idx = (idx,)
+
+    ellipsis_count = sum(item is Ellipsis for item in idx)
+    if ellipsis_count > 1:
+        raise IndexError("An index can only have a single ellipsis.")
+    if ellipsis_count == 1:
+        ellipsis_pos = idx.index(Ellipsis)
+        fill = ndim - (len(idx) - 1)
+        idx = idx[:ellipsis_pos] + (slice(None),) * fill + idx[ellipsis_pos + 1 :]
+    if len(idx) > ndim:
+        raise IndexError(f"Too many indices for Vector: expected {ndim}, got {len(idx)}")
+    if len(idx) < ndim:
+        idx = idx + (slice(None),) * (ndim - len(idx))
+    return idx
+
+
+
+def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], bool]:
+    if isinstance(axis_index, (bool, np.bool_)):
+        raise TypeError("Boolean scalars are not valid Vector indices.")
+
+    if isinstance(axis_index, (int, np.integer)):
+        index = int(axis_index)
+        if index < 0:
+            index += size
+        if index < 0 or index >= size:
+            raise IndexError("Vector index out of range")
+        return np.array([index], dtype=np.int64), True
+
+    if isinstance(axis_index, slice):
+        return np.arange(size, dtype=np.int64)[axis_index], False
+
+    array = np.asarray(axis_index)
+    if array.ndim == 0:
+        if np.issubdtype(array.dtype, np.integer):
+            return _positions_for_axis(int(array.item()), size)
+        raise TypeError(f"Unsupported index type: {type(axis_index)!r}")
+
+    if array.dtype == bool or np.issubdtype(array.dtype, np.bool_):
+        if array.ndim != 1:
+            raise IndexError("Full-grid boolean masks are not supported.")
+        if array.shape[0] != size:
+            raise IndexError(f"Boolean mask length {array.shape[0]} does not match axis length {size}")
+        return np.flatnonzero(array).astype(np.int64, copy=False), False
+
+    if array.ndim != 1:
+        raise IndexError("Fancy indexing arrays must be one-dimensional.")
+    if array.size == 0:
+        return np.array([], dtype=np.int64), False
+    if not np.issubdtype(array.dtype, np.integer):
+        raise TypeError("Fancy indices must be integers or booleans.")
+
+    positions = array.astype(np.int64, copy=True)
+    positions[positions < 0] += size
+    if np.any((positions < 0) | (positions >= size)):
+        raise IndexError("Vector index out of range")
+    return positions, False
+
+
+
+def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDArray[np.generic]:
+    array = np.asarray(value)
+    if array.ndim == 0:
+        return np.broadcast_to(array.reshape(1, 1), (total_rows, num_fields))
+    if num_fields == 1 and array.ndim == 1:
+        if total_rows == 0 and array.shape[0] == 0:
+            return array.reshape(0, 1)
+        if array.shape[0] != total_rows:
+            raise ValueError(f"Expected {total_rows} values, got {array.shape[0]}")
+        return array.reshape(total_rows, 1)
     try:
-        array = np.asarray(node)
-    except Exception:
-        return False
-    return array.ndim == 2 and np.issubdtype(array.dtype, np.number)
+        return np.broadcast_to(array, (total_rows, num_fields))
+    except ValueError as exc:
+        raise ValueError(
+            f"Cannot broadcast value with shape {array.shape} to ({total_rows}, {num_fields})"
+        ) from exc
+
+
+
+def _is_contiguous(indices: NDArray[np.int64]) -> bool:
+    if indices.size <= 1:
+        return True
+    return bool(np.all(indices[1:] - indices[:-1] == 1))

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -1,1026 +1,694 @@
-from typing import (
-    Any,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-    overload,
-)
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence, overload
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import NDArray
 
 from quantem.core.io.serialize import AutoSerialize
 from quantem.core.utils.validators import (
     validate_fields,
     validate_num_fields,
     validate_shape,
-    validate_vector_data,
-    validate_vector_data_for_inference,
     validate_vector_units,
 )
 
 
+@dataclass
+class _VectorState:
+    shape: tuple[int, ...]
+    data: NDArray[np.object_]
+    fields: list[str]
+    units: list[str]
+    name: str
+    metadata: dict[str, Any]
+
+
 class Vector(AutoSerialize):
+    """Ragged cell data on a fixed grid.
+
+    A ``Vector`` has fixed grid dimensions (``shape``). Each fixed-grid cell stores a
+    NumPy array with shape ``(n_rows, num_fields)``. Selections always return new
+    ``Vector`` views over the same backing store, while raw NumPy extraction is explicit
+    via ``.array`` and ``.flatten()``.
     """
-    A class for holding vector data with ragged array lengths. This class supports any number of fixed dimensions
-    (indexed first) followed by a ragged numpy array that can have any number of entries (rows) and columns (fields).
-    Inherits from AutoSerialize for serialization support.
-
-    Basic Usage:
-    -----------
-    # Create a 2D vector with shape=(4, 3) and 3 named fields
-    v = Vector.from_shape(shape=(4, 3), fields=['field0', 'field1', 'field2'])
-
-    # Alternative creation with num_fields instead of fields
-    v = Vector.from_shape(shape=(4, 3), num_fields=3)  # Fields will be named field_0, field_1, field_2
-
-    # Create with custom name and units
-    v = Vector.from_shape(
-        shape=(4, 3),
-        fields=['field0', 'field1', 'field2'],
-        name='my_vector',
-        units=['unit0', 'unit1', 'unit2'],
-    )
-
-    # Access data at specific indices
-    data = v[0, 1]  # Returns numpy array at position (0,1)
-
-    # Set data at specific indices
-    v[0, 1] = np.array([[1.0, 2.0, 3.0]])  # Must match num_fields
-
-    # Create a deep copy
-    v_copy = v.copy()
-
-    Example usage of from_data:
-    -----------------------------------
-    data = [
-        np.array([[1, 2], [3, 4]]),
-        np.array([[5, 6], [7, 8], [9, 10]])
-    ]
-    v = Vector.from_data(
-        data,
-        fields=['x', 'y'],
-        name='my_ragged_vector',
-        units=['m', 'm']
-    )
-
-    # Or using lists instead of numpy arrays:
-    data = [
-        [[1, 2], [3, 4]],
-        [[5, 6], [7, 8], [9, 10]],
-    ]
-    v = Vector.from_data(
-        data,
-        fields=['x', 'y'],
-        name='my_ragged_vector',
-        units=['m', 'm']
-    )
-
-    Field Operations:
-    ----------------
-    # Access a specific field
-    field_data = v['field0']  # Returns a FieldView object
-
-    # Perform operations on a field
-    v['field0'] += 16  # Add 16 to all field0 values
-
-    # Apply a function to a field
-    v['field2'] = lambda x: x * 2  # Double all field2 values
-
-    # Get flattened field data
-    field_flat = v['field0'].flatten()  # Returns 1D numpy array
-
-    # Set field data from flattened array
-    v['field2'].set_flattened(new_values)  # Must match total length
-
-    Advanced Operations:
-    -------------------
-    # Complex field calculations
-    scale = v['field0'].flatten() / (v['field0'].flatten()**2 + v['field1'].flatten()**2)
-    v['field2'].set_flattened(v['field2'].flatten() * scale)
-
-    # Slicing and assignment
-    v[2:4, 1] = v[1:3, 1]  # Copy data from one region to another
-
-    # Boolean indexing
-    mask = v['field0'].flatten() > 0
-    v['field2'].set_flattened(v['field2'].flatten() * mask)
-
-    # Field management
-    v.add_fields(('field3', 'field4', 'field5'))  # Add new fields
-    v.remove_fields(('field3', 'field4', 'field5'))  # Remove fields
-
-    Direct Data Access:
-    ------------------
-    # Get data with integer indexing
-    data = v.get_data(0, 1)  # Returns numpy array at (0,1)
-
-    # Get data with slice indexing
-    data = v.get_data(slice(0, 2), 1)  # Returns list of arrays for rows 0-1 at column 1
-
-    # Set data with integer indexing
-    v.set_data(np.array([[1.0, 2.0, 3.0]]), 0, 1)  # Set data at (0,1)
-
-    # Set data with slice indexing
-    v.set_data([np.array([[1.0, 2.0, 3.0]]), np.array([[4.0, 5.0, 6.0]])],
-               slice(0, 2), 1)  # Set data for rows 0-1 at column 1
-
-    Notes:
-    -----
-    - All numpy arrays stored in the vector must have the same number of columns (fields)
-    - Field names must be unique
-    - Slicing operations return new Vector instances
-    - Field operations are performed in-place
-    - Units are stored for each field and can be accessed via the units attribute
-    - The name attribute can be used to identify the vector in a larger context
-    """
-
-    _token = object()
 
     def __init__(
         self,
-        shape: Tuple[int, ...],
-        fields: List[str],
-        units: List[str],
-        name: str,
-        metadata: dict = {},
-        _token: object | None = None,
+        shape: tuple[int, ...],
+        fields: Sequence[str],
+        units: Sequence[str] | None = None,
+        name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> None:
-        if _token is not self._token:
-            raise RuntimeError("Use Vector.from_shape() or Vector.from_data() to instantiate.")
+        validated_shape = validate_shape(shape)
+        validated_fields = validate_fields(list(fields))
+        validated_units = validate_vector_units(list(units) if units is not None else None, len(validated_fields))
+        self._state = _VectorState(
+            shape=validated_shape,
+            data=_empty_storage(validated_shape, len(validated_fields)),
+            fields=list(validated_fields),
+            units=list(validated_units),
+            name=name or f"{len(validated_shape)}d ragged array",
+            metadata=dict(metadata or {}),
+        )
+        self._coords = _root_coords(validated_shape)
+        self._field_names = tuple(validated_fields)
 
-        self.shape = shape
-        self.fields = fields
-        self.units = units
-        self.name = name
-        self._data = nested_list(self.shape, fill=None)
-        self._metadata = metadata
+    @classmethod
+    def _from_state(
+        cls,
+        state: _VectorState,
+        coords: NDArray[np.object_],
+        field_names: Sequence[str],
+    ) -> "Vector":
+        obj = cls.__new__(cls)
+        obj._state = state
+        obj._coords = coords
+        obj._field_names = tuple(field_names)
+        return obj
 
     @classmethod
     def from_shape(
         cls,
-        shape: Tuple[int, ...],
-        num_fields: Optional[int] = None,
-        fields: Optional[List[str]] = None,
-        units: Optional[List[str]] = None,
-        name: Optional[str] = None,
+        shape: tuple[int, ...],
+        num_fields: int | None = None,
+        fields: Sequence[str] | None = None,
+        units: Sequence[str] | None = None,
+        name: str | None = None,
     ) -> "Vector":
-        """
-        Factory method to create a Vector with the specified shape and fields.
-
-        Parameters
-        ----------
-        shape : Tuple[int, ...]
-            The shape of the vector (dimensions)
-        num_fields : Optional[int]
-            Number of fields in the vector
-        name : Optional[str]
-            Name of the vector
-        fields : Optional[List[str]]
-            List of field names
-        units : Optional[List[str]]
-            List of units for each field
-
-        Returns
-        -------
-        Vector
-            A new Vector instance
-        """
-        validated_shape = validate_shape(shape)
-        ndim = len(validated_shape)
-
         if fields is not None:
-            validated_fields = validate_fields(fields)
-            validated_num_fields = len(validated_fields)
-            if num_fields is not None and validated_num_fields != num_fields:
+            validated_fields = validate_fields(list(fields))
+            if num_fields is not None and len(validated_fields) != num_fields:
                 raise ValueError(
-                    f"num_fields ({num_fields}) does not match length of fields ({validated_num_fields})"
+                    f"num_fields ({num_fields}) does not match length of fields ({len(validated_fields)})"
                 )
         elif num_fields is not None:
-            validated_num_fields = validate_num_fields(num_fields)
-            validated_fields = [f"field_{i}" for i in range(validated_num_fields)]
+            validated_count = validate_num_fields(num_fields)
+            validated_fields = [f"field_{i}" for i in range(validated_count)]
         else:
             raise ValueError("Must specify either 'fields' or 'num_fields'.")
 
-        validated_units = validate_vector_units(units, validated_num_fields)
-        name = name or f"{ndim}d ragged array"
-
         return cls(
-            shape=validated_shape,
+            shape=shape,
             fields=validated_fields,
-            units=validated_units,
+            units=units,
             name=name,
-            _token=cls._token,
         )
 
     @classmethod
     def from_data(
         cls,
-        data: List[Any],
-        num_fields: Optional[int] = None,
-        fields: Optional[List[str]] = None,
-        units: Optional[List[str]] = None,
-        name: Optional[str] = None,
+        data: list[Any],
+        num_fields: int | None = None,
+        fields: Sequence[str] | None = None,
+        units: Sequence[str] | None = None,
+        name: str | None = None,
     ) -> "Vector":
-        """
-        Factory method to create a Vector from a list of
-        ragged lists or ragged numpy arrays.
+        inferred_shape, normalized_cells = _normalize_nested_data(data)
+        inferred_num_fields = normalized_cells[0].shape[1] if normalized_cells else 0
 
-        Parameters
-        ----------
-        data : List[Any]
-            A list of ragged lists containing the vector data.
-            Each element should be a numpy array with shape (n, num_fields).
-        num_fields : Optional[int]
-            Number of fields in the vector. If not provided, it will be inferred from the data.
-        fields : Optional[List[str]]
-            List of field names
-        units : Optional[List[str]]
-            List of units for each field
-        name : Optional[str]
-            Name of the vector
+        if fields is not None:
+            validated_fields = validate_fields(list(fields))
+            if len(validated_fields) != inferred_num_fields:
+                raise ValueError(
+                    f"num_fields ({inferred_num_fields}) does not match length of fields ({len(validated_fields)})"
+                )
+        elif num_fields is not None:
+            validated_num_fields = validate_num_fields(num_fields)
+            if validated_num_fields != inferred_num_fields:
+                raise ValueError(
+                    f"Provided num_fields ({validated_num_fields}) does not match inferred ({inferred_num_fields})."
+                )
+            validated_fields = [f"field_{i}" for i in range(validated_num_fields)]
+        else:
+            validated_fields = [f"field_{i}" for i in range(inferred_num_fields)]
 
-        Returns
-        -------
-        Vector
-            A new Vector instance with the provided data
-
-        Raises
-        ------
-        ValueError
-            If the data structure is invalid or inconsistent
-        TypeError
-            If the data contains invalid types
-        """
-        inferred_shape, inferred_num_fields = validate_vector_data_for_inference(data)
-
-        final_num_fields = num_fields or inferred_num_fields
-        if num_fields is not None and num_fields != inferred_num_fields:
-            raise ValueError(
-                f"Provided num_fields ({num_fields}) does not match inferred ({inferred_num_fields})."
-            )
-
-        vector = cls.from_shape(
+        vector = cls(
             shape=inferred_shape,
-            num_fields=final_num_fields,
-            fields=fields,
+            fields=validated_fields,
             units=units,
             name=name,
         )
-
-        # Now fully validate and set the data
-        vector.data = data
+        for coord, array in zip(np.ndindex(inferred_shape), normalized_cells):
+            vector._state.data[coord] = array.copy()
         return vector
 
-    def get_data(
-        self, *indices: Union[int, slice, List[int], np.ndarray[Any, np.dtype[Any]]]
-    ) -> Union[NDArray, List[NDArray]]:
-        """
-        Get data at specified indices.
-
-        Parameters:
-        -----------
-        *indices : Union[int, slice, List[int], np.ndarray]
-            Indices to access. Must match the number of dimensions in the vector.
-            Supports fancy indexing with lists or numpy arrays.
-
-        Returns:
-        --------
-        numpy.ndarray or list
-            The data at the specified indices.
-
-        Raises:
-        -------
-        IndexError
-            If indices are out of bounds.
-        ValueError
-            If the number of indices does not match the vector dimensions.
-        """
-        if len(indices) != len(self._shape):
-            raise ValueError(f"Expected {len(self._shape)} indices, got {len(indices)}")
-
-        # Handle fancy indexing and slicing
-        def get_indices(dim_idx: Any, dim_size: int) -> np.ndarray:
-            if isinstance(dim_idx, slice):
-                start, stop, step = dim_idx.indices(dim_size)
-                return np.arange(start, stop, step)
-            elif isinstance(dim_idx, (np.ndarray, list)):
-                idx = np.asarray(dim_idx)
-                if np.any((idx < 0) | (idx >= dim_size)):
-                    raise IndexError(f"Index out of bounds for axis with size {dim_size}")
-                return idx
-            elif isinstance(dim_idx, (int, np.integer)):
-                if dim_idx < 0 or dim_idx >= dim_size:
-                    raise IndexError(
-                        f"Index {dim_idx} out of bounds for axis with size {dim_size}"
-                    )
-                return np.array([dim_idx])
-            return np.arange(dim_size)
-
-        # Get indices for each dimension
-        indices_arrays = [get_indices(i, s) for i, s in zip(indices, self._shape)]
-
-        # If all indices are single integers, return a single array
-        if all(len(i) == 1 for i in indices_arrays):
-            ref = self._data
-            for idx in (i[0] for i in indices_arrays):
-                ref = ref[idx]
-            return ref
-
-        # Create result structure for fancy indexing
-        result = []
-        for idx in np.ndindex(*[len(i) for i in indices_arrays]):
-            src_idx = tuple(ind[i] for ind, i in zip(indices_arrays, idx))
-            result.append(self._data[src_idx[0]][src_idx[1]])
-
-        return result
-
-    def set_data(
-        self,
-        value: Union[NDArray, List[NDArray]],
-        *indices: Union[int, slice, List[int], np.ndarray[Any, np.dtype[Any]]],
-    ) -> None:
-        """
-        Set data at specified indices.
-
-        Parameters
-        ----------
-        value : Union[NDArray, List[NDArray]]
-            The numpy array(s) to set at the specified indices. Must have shape (_, num_fields).
-            For fancy indexing, can be a list of arrays.
-        *indices : Union[int, slice, List[int], np.ndarray]
-            Indices to set data at. Must match the number of dimensions in the vector.
-            Supports fancy indexing with lists or numpy arrays.
-
-        Raises
-        ------
-        IndexError
-            If indices are out of bounds.
-        ValueError
-            If the number of indices does not match the vector dimensions,
-            or if the value shape doesn't match the expected shape.
-        TypeError
-            If the value is not a numpy array or list of numpy arrays.
-        """
-        if len(indices) != len(self._shape):
-            raise ValueError(f"Expected {len(self._shape)} indices, got {len(indices)}")
-
-        # Handle fancy indexing and slicing
-        def get_indices(dim_idx: Any, dim_size: int) -> np.ndarray:
-            if isinstance(dim_idx, slice):
-                start, stop, step = dim_idx.indices(dim_size)
-                return np.arange(start, stop, step)
-            elif isinstance(dim_idx, (np.ndarray, list)):
-                idx = np.asarray(dim_idx)
-                if np.any((idx < 0) | (idx >= dim_size)):
-                    raise IndexError(f"Index out of bounds for axis with size {dim_size}")
-                return idx
-            elif isinstance(dim_idx, (int, np.integer)):
-                if dim_idx < 0 or dim_idx >= dim_size:
-                    raise IndexError(
-                        f"Index {dim_idx} out of bounds for axis with size {dim_size}"
-                    )
-                return np.array([dim_idx])
-            return np.arange(dim_size)
-
-        # Get indices for each dimension
-        indices_arrays = [get_indices(i, s) for i, s in zip(indices, self._shape)]
-
-        # If all indices are single integers, handle as single value
-        if all(len(i) == 1 for i in indices_arrays):
-            if not isinstance(value, np.ndarray):
-                raise TypeError(f"Value must be a numpy array, got {type(value).__name__}")
-            if value.ndim != 2 or value.shape[1] != self.num_fields:
-                raise ValueError(
-                    f"Expected a numpy array with shape (_, {self.num_fields}), got {value.shape}"
-                )
-            ref = self._data
-            for idx in (i[0] for i in indices_arrays[:-1]):
-                ref = ref[idx]
-            ref[indices_arrays[-1][0]] = value
-            return
-
-        # Handle fancy indexing
-        if not isinstance(value, list):
-            raise TypeError("For fancy indexing, value must be a list of numpy arrays")
-
-        # Validate and set values
-        for idx in np.ndindex(*[len(i) for i in indices_arrays]):
-            src_idx = tuple(ind[i] for ind, i in zip(indices_arrays, idx))
-            if not isinstance(value[idx[0]], np.ndarray):
-                raise TypeError(f"Expected numpy array, got {type(value[idx[0]]).__name__}")
-            if value[idx[0]].ndim != 2 or value[idx[0]].shape[1] != self.num_fields:
-                raise ValueError(
-                    f"Expected array with shape (_, {self.num_fields}), got {value[idx[0]].shape}"
-                )
-            ref = self._data
-            for i in src_idx[:-1]:
-                ref = ref[i]
-            ref[src_idx[-1]] = value[idx[0]]
-
-    @overload
-    def __getitem__(self, idx: str) -> "_FieldView": ...
-    @overload
-    def __getitem__(
-        self,
-        idx: Union[Tuple[Union[int, slice, List[int]], ...], int, slice, List[int]],
-    ) -> Union[NDArray, "Vector"]: ...
-
-    def __getitem__(
-        self,
-        idx: Union[str, Tuple[Union[int, slice, List[int]], ...], int, slice, List[int]],
-    ) -> Union["_FieldView", NDArray, "Vector"]:
-        """Get data or a view of the vector at specified indices."""
-        if isinstance(idx, str):
-            if idx not in self._fields:
-                raise KeyError(f"Field '{idx}' not found.")
-            return _FieldView(self, idx)
-
-        # Normalize idx to tuple
-        normalized: Tuple[Any, ...] = (idx,) if not isinstance(idx, tuple) else idx
-
-        # Convert lists/arrays to ndarray
-        idx_converted: Tuple[Union[int, slice, np.ndarray[Any, np.dtype[Any]]], ...] = tuple(
-            np.asarray(i) if isinstance(i, (list, np.ndarray)) else i for i in normalized
-        )
-
-        # Check if we should return a numpy array (all indices are integers)
-        return_np = all(isinstance(i, (int, np.integer)) for i in idx_converted[: len(self.shape)])
-        if len(idx_converted) < len(self.shape):
-            return_np = False
-
-        if return_np:
-            view = self._data
-            for i in idx_converted:
-                view = view[i]
-            return cast(NDArray[Any], view)
-
-        # Handle fancy indexing and slicing
-        def get_indices(dim_idx: Any, dim_size: int) -> np.ndarray:
-            if isinstance(dim_idx, slice):
-                start, stop, step = dim_idx.indices(dim_size)
-                return np.arange(start, stop, step)
-            elif isinstance(dim_idx, (np.ndarray, list)):
-                return np.asarray(dim_idx)
-            elif isinstance(dim_idx, (int, np.integer)):
-                return np.array([dim_idx])
-            return np.arange(dim_size)
-
-        # Get indices for each dimension
-        full_idx = list(idx_converted) + [slice(None)] * (len(self.shape) - len(idx_converted))
-        indices = [get_indices(i, s) for i, s in zip(full_idx, self.shape)]
-
-        # Create new shape and data
-        new_shape = [len(i) for i in indices]
-        new_data = [[None] * new_shape[-1] for _ in range(new_shape[0])]
-
-        # Fill the new data structure
-        for out_idx in np.ndindex(*new_shape):
-            src_idx = tuple(ind[i] for ind, i in zip(indices, out_idx))
-            new_data[out_idx[0]][out_idx[1]] = self._data[src_idx[0]][src_idx[1]]
-
-        # Create new Vector
-        vector_new = Vector.from_shape(
-            shape=tuple(new_shape),
-            num_fields=self.num_fields,
-            name=self.name + "[view]",
-            fields=self.fields,
-            units=self.units,
-        )
-        vector_new._data = new_data
-        return vector_new
-
-    def __setitem__(
-        self,
-        idx: Union[Tuple[Union[int, slice, List[int]], ...], int, slice, List[int], str],
-        value: Union[NDArray, List[NDArray]],
-    ) -> None:
-        """Set data at specified indices."""
-        if isinstance(idx, str):
-            if idx not in self._fields:
-                raise KeyError(f"Field '{idx}' not found.")
-            field_view = _FieldView(self, idx)
-            field_view.set_flattened(value)
-            return
-
-        # Normalize idx to tuple
-        normalized: Tuple[Any, ...] = (idx,) if not isinstance(idx, tuple) else idx
-
-        # Convert lists/arrays to ndarray
-        idx_converted: Tuple[Union[int, slice, np.ndarray[Any, np.dtype[Any]]], ...] = tuple(
-            np.asarray(i) if isinstance(i, (list, np.ndarray)) else i for i in normalized
-        )
-
-        # Check if we're doing slice‐ or array‐based (multi‐cell) indexing
-        has_fancy = any(
-            isinstance(i, slice) or (isinstance(i, np.ndarray) and i.size > 1)
-            for i in idx_converted[: len(self.shape)]
-        )
-
-        if has_fancy:
-            # If user passed a Vector, extract its cell arrays
-            if isinstance(value, Vector):
-
-                def _flatten_cells(data):
-                    if isinstance(data, np.ndarray):
-                        return [data]
-                    out = []
-                    for sub in data:
-                        out.extend(_flatten_cells(sub))
-                    return out
-
-                value = _flatten_cells(value._data)
-
-            # For fancy indexing, value should be a list of arrays
-            if not isinstance(value, list):
-                raise TypeError(
-                    "For fancy/slice indexing, value must be a list of numpy arrays or a Vector"
-                )
-
-            # Get indices for each dimension
-            def get_indices(dim_idx: Any, dim_size: int) -> np.ndarray:
-                if isinstance(dim_idx, slice):
-                    start, stop, step = dim_idx.indices(dim_size)
-                    return np.arange(start, stop, step)
-                elif isinstance(dim_idx, (np.ndarray, list)):
-                    idx = np.asarray(dim_idx)
-                    if np.any((idx < 0) | (idx >= dim_size)):
-                        raise IndexError(f"Index out of bounds for axis with size {dim_size}")
-                    return idx
-                elif isinstance(dim_idx, (int, np.integer)):
-                    if dim_idx < 0 or dim_idx >= dim_size:
-                        raise IndexError(f"Index out of bounds for axis with size {dim_size}")
-                    return np.array([dim_idx])
-                return np.arange(dim_size)
-
-            indices_arrays = [get_indices(i, s) for i, s in zip(idx_converted, self._shape)]
-            total_indices = np.prod([len(i) for i in indices_arrays])
-
-            if len(value) != total_indices:
-                raise ValueError(f"Expected {total_indices} arrays, got {len(value)}")
-
-            # Validate and set values
-            for array_idx, idx in enumerate(np.ndindex(*[len(i) for i in indices_arrays])):
-                src_idx = tuple(ind[i] for ind, i in zip(indices_arrays, idx))
-                if not isinstance(value[array_idx], np.ndarray):
-                    raise TypeError(f"Expected numpy array, got {type(value[array_idx]).__name__}")
-                if value[array_idx].ndim != 2 or value[array_idx].shape[1] != self.num_fields:
-                    raise ValueError(
-                        f"Expected array with shape (_, {self.num_fields}), got {value[array_idx].shape}"
-                    )
-                ref = self._data
-                for i in src_idx[:-1]:
-                    ref = ref[i]
-                ref[src_idx[-1]] = value[array_idx]
-        else:
-            # For single value assignment
-            if not isinstance(value, np.ndarray):
-                raise TypeError(f"Value must be a numpy array, got {type(value).__name__}")
-            if value.ndim != 2 or value.shape[1] != self.num_fields:
-                raise ValueError(
-                    f"Expected a numpy array with shape (_, {self.num_fields}), got {value.shape}"
-                )
-            ref = self._data
-            for i in idx_converted[:-1]:
-                ref = ref[i]
-            ref[idx_converted[-1]] = value
-
-    def add_fields(self, new_fields: Union[str, List[str]]) -> None:
-        """
-        Add new fields to the vector.
-
-        Parameters
-        ----------
-        new_fields : Union[str, List[str]]
-            Field name(s) to add. Must be unique and not already present.
-
-        Raises
-        ------
-        ValueError
-            If any field name already exists or if there are duplicates
-        """
-        if isinstance(new_fields, str):
-            new_fields = [new_fields]
-        else:
-            new_fields = list(new_fields)
-
-        if any(name in self._fields for name in new_fields):
-            raise ValueError("One or more new field names already exist.")
-
-        if len(set(new_fields)) != len(new_fields):
-            raise ValueError("Duplicate field names in input are not allowed.")
-
-        self._fields = list(self._fields) + list(new_fields)
-        self._units = list(self._units) + ["none"] * len(new_fields)
-
-        def expand_array(arr: Any) -> Any:
-            if isinstance(arr, np.ndarray):
-                if arr.shape[1] != self.num_fields - len(new_fields):
-                    raise ValueError(
-                        f"Expected arrays with {self.num_fields - len(new_fields)} fields, got {arr.shape[1]}"
-                    )
-                pad = np.zeros((arr.shape[0], len(new_fields)))
-                return np.hstack([arr, pad])
-            elif isinstance(arr, list):
-                return [expand_array(sub) for sub in arr]
-            else:
-                return arr
-
-        self._data = expand_array(self._data)
-
-    def remove_fields(self, fields_to_remove: Union[str, List[str]]) -> None:
-        """
-        Remove fields from the vector.
-
-        Parameters
-        ----------
-        fields_to_remove : Union[str, List[str]]
-            Field name(s) to remove. Must exist in the vector.
-
-        Raises
-        ------
-        ValueError
-            If any field doesn't exist
-        """
-        if isinstance(fields_to_remove, str):
-            fields_to_remove = [fields_to_remove]
-        else:
-            fields_to_remove = list(fields_to_remove)
-
-        field_to_index = {name: i for i, name in enumerate(self._fields)}
-        indices_to_remove = []
-        for field in fields_to_remove:
-            if field not in field_to_index:
-                print(f"Warning: field '{field}' not found.")
-            else:
-                indices_to_remove.append(field_to_index[field])
-
-        if not indices_to_remove:
-            return
-
-        indices_to_remove = sorted(set(indices_to_remove))
-        keep_indices = [i for i in range(self.num_fields) if i not in indices_to_remove]
-
-        # Update metadata
-        self._fields = [self._fields[i] for i in keep_indices]
-        self._units = [self._units[i] for i in keep_indices]
-
-        def prune_array(arr: Any) -> Any:
-            if isinstance(arr, np.ndarray):
-                if arr.shape[1] < max(indices_to_remove) + 1:
-                    raise ValueError(
-                        f"Cannot remove field index {max(indices_to_remove)} from array with shape {arr.shape}"
-                    )
-                return arr[:, keep_indices]
-            elif isinstance(arr, list):
-                return [prune_array(sub) for sub in arr]
-            else:
-                return arr
-
-        self._data = prune_array(self._data)
-
-    def copy(self) -> "Vector":
-        """
-        Create a deep copy of the vector.
-
-        Returns
-        -------
-        Vector
-            A new Vector instance with the same data, shape, fields, and units.
-        """
-        import copy
-
-        vector_copy = Vector.from_shape(
-            shape=self.shape,
-            name=self.name,
-            fields=self.fields,
-            units=self.units,
-        )
-        vector_copy._data = copy.deepcopy(self._data)
-        return vector_copy
-
-    def flatten(self) -> NDArray:
-        """
-        Flatten the vector into a 2D numpy array.
-
-        Returns
-        -------
-        NDArray
-            A 2D numpy array containing all data, with shape (total_rows, num_fields).
-        """
-
-        def collect_arrays(data: Any) -> List[NDArray]:
-            if isinstance(data, np.ndarray):
-                return [data]
-            elif isinstance(data, list):
-                arrays = []
-                for item in data:
-                    arrays.extend(collect_arrays(item))
-                return arrays
-            else:
-                return []
-
-        arrays = collect_arrays(self._data)
-        if not arrays:
-            return np.empty((0, self.num_fields))
-        return np.vstack(arrays)
-
-    def __repr__(self) -> str:
-        description = [
-            f"quantem.Vector, shape={self._shape}, name={self._name}",
-            f"  fields = {self._fields}",
-            f"  units: {self._units}",
-        ]
-        return "\n".join(description)
-
-    def __str__(self) -> str:
-        description = [
-            f"quantem.Vector, shape={self._shape}, name={self._name}",
-            f"  fields = {self._fields}",
-            f"  units: {self._units}",
-        ]
-        return "\n".join(description)
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self._coords.shape
 
     @property
-    def metadata(self) -> dict:
-        return self._metadata
+    def fields(self) -> list[str]:
+        return list(self._field_names)
 
     @property
-    def shape(self) -> Tuple[int, ...]:
-        """
-        Get the shape of the vector.
-
-        Returns
-        -------
-        Tuple[int, ...]
-            The dimensions of the vector.
-        """
-        return self._shape
-
-    @shape.setter
-    def shape(self, value: Tuple[int, ...]) -> None:
-        """
-        Set the shape of the vector.
-
-        Parameters
-        ----------
-        value : Tuple[int, ...]
-            The new shape. All dimensions must be positive.
-
-        Raises
-        ------
-        ValueError
-            If any dimension is not positive.
-        TypeError
-            If value is not a tuple or contains non-integer values.
-        """
-        self._shape = validate_shape(value)
+    def units(self) -> list[str]:
+        lookup = {name: unit for name, unit in zip(self._state.fields, self._state.units)}
+        return [lookup[name] for name in self._field_names]
 
     @property
     def num_fields(self) -> int:
-        """
-        Get the number of fields in the vector.
-
-        Returns
-        -------
-        int
-            The number of fields.
-        """
-        return len(self._fields)
+        return len(self._field_names)
 
     @property
     def name(self) -> str:
-        """
-        Get the name of the vector.
-
-        Returns
-        -------
-        str
-            The name of the vector
-        """
-        return self._name
+        return self._state.name
 
     @name.setter
     def name(self, value: str) -> None:
-        """
-        Set the name of the vector.
-
-        Parameters
-        ----------
-        value : str
-            The new name of the vector
-        """
-        self._name = str(value)
+        self._state.name = str(value)
 
     @property
-    def fields(self) -> List[str]:
-        """
-        Get the field names of the vector.
-
-        Returns
-        -------
-        List[str]
-            The list of field names.
-        """
-        return self._fields
-
-    @fields.setter
-    def fields(self, value: List[str]) -> None:
-        """
-        Set the field names of the vector.
-
-        Parameters
-        ----------
-        value : List[str]
-            The new field names. Must match num_fields and be unique.
-
-        Raises
-        ------
-        ValueError
-            If length doesn't match num_fields or if there are duplicates.
-        TypeError
-            If value is not a list or contains non-string values.
-        """
-        self._fields = validate_fields(value)
+    def metadata(self) -> dict[str, Any]:
+        return self._state.metadata
 
     @property
-    def units(self) -> List[str]:
-        """
-        Get the units of the vector's fields.
+    def array(self) -> NDArray[np.generic]:
+        if self.shape != ():
+            raise ValueError(".array is only valid when the selection contains exactly one cell.")
+        coord = self._coords[()]
+        cell = self._state.data[coord]
+        indices = self._field_indices()
+        if len(indices) == len(self._state.fields) and indices == list(range(len(self._state.fields))):
+            return cell
+        if len(indices) == 1:
+            idx = indices[0]
+            return cell[:, idx : idx + 1]
+        if _is_contiguous(indices):
+            return cell[:, indices[0] : indices[-1] + 1]
+        return cell[:, indices].copy()
 
-        Returns
-        -------
-        List[str]
-            The list of units, one per field.
-        """
-        return self._units
+    def __len__(self) -> int:
+        if self.shape == ():
+            raise TypeError("len() of unsized 0D Vector")
+        return self.shape[0]
 
-    @units.setter
-    def units(self, value: List[str]) -> None:
-        """
-        Set the units of the vector's fields.
+    def __repr__(self) -> str:
+        return f"quantem.Vector(shape={self.shape}, fields={self.fields}, name={self.name!r})"
 
-        Parameters
-        ----------
-        value : List[str]
-            The new units. Must match num_fields.
+    __str__ = __repr__
 
-        Raises
-        ------
-        ValueError
-            If length doesn't match num_fields.
-        TypeError
-            If value is not a list or contains non-string values.
-        """
-        self._units = validate_vector_units(value, self.num_fields)
+    def copy(self) -> "Vector":
+        copied = self.__class__._from_state(
+            _VectorState(
+                shape=self.shape,
+                data=_empty_storage(self.shape, self.num_fields),
+                fields=self.fields,
+                units=self.units,
+                name=self.name,
+                metadata=copy.deepcopy(self.metadata),
+            ),
+            _root_coords_allow_empty(self.shape),
+            self.fields,
+        )
+        for coord, array in zip(np.ndindex(self.shape) if self.shape != () else [()], self._iter_selected_arrays()):
+            copied._state.data[coord] = array.copy()
+        return copied
 
-    @property
-    def data(self) -> List[Any]:
-        """
-        Get the raw data of the vector.
+    def flatten(self) -> NDArray[np.generic]:
+        arrays = [array for array in self._iter_selected_arrays() if array.shape[0] > 0]
+        if arrays:
+            return np.vstack(arrays)
+        dtype = float
+        for array in self._iter_selected_arrays():
+            dtype = array.dtype
+            break
+        return np.empty((0, self.num_fields), dtype=dtype)
 
-        Returns
-        -------
-        List[Any]
-            The nested list structure containing the vector's data.
-        """
-        return self._data
+    def select_fields(self, field_names: str | Sequence[str]) -> "Vector":
+        normalized = _normalize_field_names(field_names)
+        available = set(self._field_names)
+        missing = [name for name in normalized if name not in available]
+        if missing:
+            raise KeyError(f"Unknown field(s): {missing}")
+        return self._from_state(self._state, self._coords, normalized)
 
-    @data.setter
-    def data(self, value: List[Any]) -> None:
-        """
-        Set the raw data of the vector.
+    def add_fields(
+        self,
+        names: str | Sequence[str],
+        values: Any | None = None,
+        units: str | Sequence[str] | None = None,
+    ) -> None:
+        new_names = _normalize_field_names(names)
+        if any(name in self._state.fields for name in new_names):
+            raise ValueError("One or more new field names already exist.")
 
-        Parameters
-        ----------
-        value : List[Any]
-            The new data structure. Must match the vector's shape and num_fields.
+        new_units = _normalize_units(units, len(new_names))
+        old_fields = list(self._state.fields)
+        self._state.fields.extend(new_names)
+        self._state.units.extend(new_units)
 
-        Raises
-        ------
-        ValueError
-            If the data structure doesn't match shape or num_fields.
-        TypeError
-            If value is not a list or contains invalid data types.
-        """
-        self._data = validate_vector_data(value, self.shape, self.num_fields)
+        old_width = len(old_fields)
+        new_width = len(self._state.fields)
+        for coord in np.ndindex(self._state.shape) if self._state.shape != () else [()]:
+            current = self._state.data[coord]
+            promoted = np.result_type(current.dtype, float)
+            expanded = np.full((current.shape[0], new_width), np.nan, dtype=promoted)
+            expanded[:, :old_width] = current
+            self._state.data[coord] = expanded
 
+        if list(self._field_names) == old_fields:
+            self._field_names = tuple(self._state.fields)
 
-# Helper function for nesting lists
-def nested_list(shape: Tuple[int, ...], fill: Any = None) -> Any:
-    if len(shape) == 0:
-        return fill
-    return [nested_list(shape[1:], fill) for _ in range(shape[0])]
+        target = self._from_state(self._state, self._coords, new_names)
+        if values is None:
+            return
 
+        if len(new_names) > 1 and isinstance(values, (list, tuple)) and len(values) == len(new_names):
+            for name, value in zip(new_names, values):
+                target.select_fields(name)._assign(value)
+        else:
+            target._assign(values)
 
-# Helper class for numerical field operations
-class _FieldView:
-    def __init__(self, vector: Vector, field_name: str) -> None:
-        self.vector = vector
-        self.field_name = field_name
-        self.field_index = vector._fields.index(field_name)
+    def remove_fields(self, names: str | Sequence[str]) -> None:
+        to_remove = _normalize_field_names(names)
+        missing = [name for name in to_remove if name not in self._state.fields]
+        if missing:
+            raise KeyError(f"Unknown field(s): {missing}")
+        if len(to_remove) == len(self._state.fields):
+            raise ValueError("Cannot remove all fields from a Vector.")
 
-    def _apply_op(self, op: Any) -> None:
-        def apply(arr: Any) -> None:
-            if isinstance(arr, np.ndarray):
-                arr[:, self.field_index] = op(arr[:, self.field_index])
-            elif isinstance(arr, list):
-                for sub in arr:
-                    apply(sub)
+        remove_set = set(to_remove)
+        keep_names = [name for name in self._state.fields if name not in remove_set]
+        keep_indices = [self._state.fields.index(name) for name in keep_names]
+        keep_units = [self._state.units[index] for index in keep_indices]
 
-        apply(self.vector._data)
+        for coord in np.ndindex(self._state.shape) if self._state.shape != () else [()]:
+            self._state.data[coord] = self._state.data[coord][:, keep_indices]
 
-    def __iadd__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place addition (+=)."""
-        self._apply_op(lambda x: x + other)
+        self._state.fields = keep_names
+        self._state.units = keep_units
+        self._field_names = tuple(name for name in self._field_names if name in keep_names)
+
+    def get_data(self, *indices: Any) -> NDArray[np.generic] | list[NDArray[np.generic]]:
+        if len(indices) != len(self.shape):
+            raise ValueError(f"Expected {len(self.shape)} indices, got {len(indices)}")
+        selection = self[indices if len(indices) != 1 else indices[0]]
+        if selection.shape == ():
+            return selection.array
+        return [array.copy() for array in selection._iter_selected_arrays()]
+
+    def set_data(self, value: Any, *indices: Any) -> None:
+        if len(indices) != len(self.shape):
+            raise ValueError(f"Expected {len(self.shape)} indices, got {len(indices)}")
+        self[indices if len(indices) != 1 else indices[0]] = value
+
+    @overload
+    def __getitem__(self, idx: Any) -> "Vector": ...
+
+    def __getitem__(self, idx: Any) -> "Vector":
+        if _is_field_selector(idx):
+            raise TypeError("Use select_fields(...) for field selection.")
+        coords = _select_coords(self._coords, idx)
+        return self._from_state(self._state, coords, self._field_names)
+
+    def __setitem__(self, idx: Any, value: Any) -> None:
+        if _is_field_selector(idx):
+            raise TypeError("Use select_fields(...) for field selection.")
+        self[idx]._assign(value)
+
+    def __add__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.add)
+
+    def __sub__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.subtract)
+
+    def __mul__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.multiply)
+
+    def __truediv__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.divide)
+
+    def __pow__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.power)
+
+    def __iadd__(self, other: Any) -> "Vector":
+        return self._binary_op_inplace(other, np.add)
+
+    def __isub__(self, other: Any) -> "Vector":
+        return self._binary_op_inplace(other, np.subtract)
+
+    def __imul__(self, other: Any) -> "Vector":
+        return self._binary_op_inplace(other, np.multiply)
+
+    def __itruediv__(self, other: Any) -> "Vector":
+        return self._binary_op_inplace(other, np.divide)
+
+    def __ipow__(self, other: Any) -> "Vector":
+        return self._binary_op_inplace(other, np.power)
+
+    def _binary_op(self, other: Any, op: Any) -> "Vector":
+        result = self.copy()
+        result._binary_op_inplace(other, op)
+        return result
+
+    def _binary_op_inplace(self, other: Any, op: Any) -> "Vector":
+        row_counts = self._row_counts()
+        targets = list(self._iter_coords())
+
+        if isinstance(other, Vector):
+            self._validate_vector_rhs(other, require_matching_rows=True)
+            source_arrays = list(other._iter_selected_arrays())
+            for coord, current, rhs in zip(targets, self._iter_selected_arrays(), source_arrays):
+                updated = current.copy()
+                op(updated, rhs, out=updated, casting="same_kind")
+                self._write_selected_array(coord, updated)
+            return self
+
+        rhs_matrix = _broadcast_rhs(np.asarray(other), sum(row_counts), self.num_fields)
+        cursor = 0
+        for coord, current, row_count in zip(targets, self._iter_selected_arrays(), row_counts):
+            chunk = rhs_matrix[cursor : cursor + row_count]
+            cursor += row_count
+            updated = current.copy()
+            op(updated, chunk, out=updated, casting="same_kind")
+            self._write_selected_array(coord, updated)
         return self
 
-    def __isub__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place subtraction (-=)."""
-        self._apply_op(lambda x: x - other)
-        return self
+    def _assign(self, value: Any) -> None:
+        if self._is_full_field_selection():
+            self._assign_full_cells(value)
+        else:
+            self._assign_selected_fields(value)
 
-    def __imul__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place multiplication (*=)."""
-        self._apply_op(lambda x: x * other)
-        return self
+    def _assign_full_cells(self, value: Any) -> None:
+        targets = list(self._iter_coords())
+        if isinstance(value, Vector):
+            self._validate_vector_rhs(value, require_matching_rows=False)
+            for target, source in zip(targets, value._iter_selected_arrays()):
+                self._state.data[target] = source.copy()
+            return
 
-    def __itruediv__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place division (/=)."""
-        self._apply_op(lambda x: x / other)
-        return self
+        array = _coerce_cell_array(value, self.num_fields)
+        for target in targets:
+            self._state.data[target] = array.copy()
 
-    def __ifloordiv__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place floor division (//=)."""
-        self._apply_op(lambda x: x // other)
-        return self
+    def _assign_selected_fields(self, value: Any) -> None:
+        targets = list(self._iter_coords())
+        row_counts = self._row_counts()
+        if isinstance(value, Vector):
+            self._validate_vector_rhs(value, require_matching_rows=True)
+            for coord, source in zip(targets, value._iter_selected_arrays()):
+                self._write_selected_array(coord, source)
+            return
 
-    def __imod__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place modulo (%=)."""
-        self._apply_op(lambda x: x % other)
-        return self
+        if np.isscalar(value):
+            for coord in targets:
+                current = self._selected_array_for_coord(coord)
+                fill = np.full(current.shape, value)
+                self._write_selected_array(coord, fill)
+            return
 
-    def __ipow__(self, other: Union[float, int, np.ndarray]) -> "_FieldView":
-        """Handle in-place power (**=)."""
-        self._apply_op(lambda x: x**other)
-        return self
+        rhs_matrix = _broadcast_rhs(np.asarray(value), sum(row_counts), self.num_fields)
+        cursor = 0
+        for coord, row_count in zip(targets, row_counts):
+            chunk = rhs_matrix[cursor : cursor + row_count]
+            cursor += row_count
+            self._write_selected_array(coord, chunk)
 
-    def flatten(self) -> NDArray:
-        def collect(arr: Any) -> List[NDArray]:
-            if isinstance(arr, np.ndarray):
-                return [arr[:, self.field_index]]
-            elif isinstance(arr, list):
-                result = []
-                for sub in arr:
-                    result.extend(collect(sub))
-                return result
+    def _validate_vector_rhs(self, other: "Vector", require_matching_rows: bool) -> None:
+        if self.num_fields != other.num_fields:
+            raise ValueError(f"Expected {self.num_fields} fields, got {other.num_fields}")
+        if self._coords.size != other._coords.size:
+            raise ValueError(f"Expected {self._coords.size} cells, got {other._coords.size}")
+        if require_matching_rows:
+            left = self._row_counts()
+            right = other._row_counts()
+            if left != right:
+                raise ValueError(f"Per-cell row counts must match: {left} != {right}")
+
+    def _row_counts(self) -> list[int]:
+        return [self._state.data[coord].shape[0] for coord in self._iter_coords()]
+
+    def _iter_coords(self) -> Iterable[tuple[int, ...]]:
+        return iter(self._coords.flat)
+
+    def _iter_selected_arrays(self) -> Iterable[NDArray[np.generic]]:
+        for coord in self._iter_coords():
+            yield self._selected_array_for_coord(coord)
+
+    def _selected_array_for_coord(self, coord: tuple[int, ...]) -> NDArray[np.generic]:
+        cell = self._state.data[coord]
+        indices = self._field_indices()
+        if self._is_full_field_selection():
+            return cell
+        if len(indices) == 1:
+            idx = indices[0]
+            return cell[:, idx : idx + 1]
+        if _is_contiguous(indices):
+            return cell[:, indices[0] : indices[-1] + 1]
+        return cell[:, indices].copy()
+
+    def _write_selected_array(self, coord: tuple[int, ...], values: NDArray[np.generic]) -> None:
+        cell = self._state.data[coord]
+        if self._is_full_field_selection():
+            replacement = _coerce_cell_array(values, self.num_fields)
+            self._state.data[coord] = replacement.copy()
+            return
+
+        if values.ndim != 2 or values.shape[1] != self.num_fields:
+            raise ValueError(
+                f"Expected array with shape (_, {self.num_fields}), got {values.shape}"
+            )
+        if values.shape[0] != cell.shape[0]:
+            raise ValueError(
+                f"Expected {cell.shape[0]} rows for in-place field update, got {values.shape[0]}"
+            )
+        cell[:, self._field_indices()] = values
+
+    def _field_indices(self) -> list[int]:
+        lookup = {name: idx for idx, name in enumerate(self._state.fields)}
+        try:
+            return [lookup[name] for name in self._field_names]
+        except KeyError as exc:
+            raise KeyError(f"Unknown field '{exc.args[0]}'") from exc
+
+    def _is_full_field_selection(self) -> bool:
+        return list(self._field_names) == self._state.fields
+
+
+def _empty_storage(shape: tuple[int, ...], num_fields: int) -> NDArray[np.object_]:
+    storage = np.empty(shape if shape != () else (), dtype=object)
+    for coord in np.ndindex(shape) if shape != () else [()]:
+        storage[coord] = np.empty((0, num_fields), dtype=float)
+    return storage
+
+
+def _root_coords(shape: tuple[int, ...]) -> NDArray[np.object_]:
+    return _root_coords_allow_empty(shape)
+
+
+def _root_coords_allow_empty(shape: tuple[int, ...]) -> NDArray[np.object_]:
+    coords = np.empty(shape if shape != () else (), dtype=object)
+    for coord in np.ndindex(shape) if shape != () else [()]:
+        coords[coord] = coord
+    return coords
+
+
+def _normalize_field_names(field_names: str | Sequence[str]) -> list[str]:
+    if isinstance(field_names, str):
+        names = [field_names]
+    elif isinstance(field_names, Sequence):
+        names = [str(name) for name in field_names]
+    else:
+        raise TypeError("Field names must be a string or a sequence of strings.")
+    if not names:
+        raise ValueError("Must select at least one field.")
+    if len(set(names)) != len(names):
+        raise ValueError("Duplicate field names are not allowed.")
+    return names
+
+
+def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]:
+    if units is None:
+        return ["none"] * count
+    if isinstance(units, str):
+        if count != 1:
+            raise ValueError("A single unit string is only valid for a single new field.")
+        return [units]
+    normalized = [str(unit) for unit in units]
+    if len(normalized) != count:
+        raise ValueError(f"Expected {count} units, got {len(normalized)}")
+    return normalized
+
+
+def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
+    array = np.asarray(value)
+    if array.ndim != 2 or array.shape[1] != num_fields:
+        raise ValueError(f"Expected a numpy array with shape (_, {num_fields}), got {array.shape}")
+    if not np.issubdtype(array.dtype, np.number):
+        raise TypeError("Cell arrays must contain numeric values.")
+    return array
+
+
+def _broadcast_rhs(value: NDArray[np.generic], total_rows: int, num_fields: int) -> NDArray[np.generic]:
+    if num_fields == 1 and value.ndim == 1:
+        value = value.reshape(-1, 1)
+    try:
+        return np.broadcast_to(value, (total_rows, num_fields))
+    except ValueError as exc:
+        raise ValueError(
+            f"RHS is not broadcast-compatible with flattened target shape ({total_rows}, {num_fields})."
+        ) from exc
+
+
+def _is_field_selector(idx: Any) -> bool:
+    if isinstance(idx, str):
+        return True
+    if isinstance(idx, list | tuple) and idx:
+        if all(isinstance(item, str) for item in idx):
+            return True
+        return any(isinstance(item, str) for item in idx)
+    return False
+
+
+def _is_contiguous(indices: Sequence[int]) -> bool:
+    if not indices:
+        return False
+    return list(indices) == list(range(indices[0], indices[0] + len(indices)))
+
+
+def _select_coords(coords: NDArray[np.object_], idx: Any) -> NDArray[np.object_]:
+    shape = coords.shape
+    selectors, scalar_axes = _normalize_indices(shape, idx)
+    out_shape = tuple(len(selector) for selector, scalar in zip(selectors, scalar_axes) if not scalar)
+    result = np.empty(out_shape if out_shape != () else (), dtype=object)
+
+    if out_shape == ():
+        source = tuple(selector[0] for selector in selectors)
+        result[()] = coords[source]
+        return result
+
+    for out_index in np.ndindex(out_shape):
+        out_cursor = 0
+        source = []
+        for axis, selector in enumerate(selectors):
+            if scalar_axes[axis]:
+                source.append(selector[0])
             else:
-                return []
+                source.append(selector[out_index[out_cursor]])
+                out_cursor += 1
+        result[out_index] = coords[tuple(source)]
+    return result
 
-        arrays = collect(self.vector._data)
-        if not arrays:
-            return np.empty((0,), dtype=float)
-        return np.concatenate(arrays, axis=0)
 
-    def set_flattened(self, values: ArrayLike) -> None:
-        """
-        Set the field values across the entire Vector from a 1D flattened array.
-        """
+def _normalize_indices(shape: tuple[int, ...], idx: Any) -> tuple[list[np.ndarray], list[bool]]:
+    if shape == ():
+        if idx in ((), Ellipsis, slice(None), None):
+            return [], []
+        raise IndexError("Too many indices for a 0D Vector.")
 
-        def fill(arr: Any, values: NDArray, cursor: int) -> int:
-            if isinstance(arr, np.ndarray):
-                n = arr.shape[0]
-                arr[:, self.field_index] = values[cursor : cursor + n]
-                return cursor + n
-            elif isinstance(arr, list):
-                for sub in arr:
-                    cursor = fill(sub, values, cursor)
-                return cursor
-            return cursor
+    normalized = idx if isinstance(idx, tuple) else (idx,)
+    normalized = _expand_ellipsis(normalized, len(shape))
+    if len(normalized) > len(shape):
+        raise IndexError(f"Expected at most {len(shape)} indices, got {len(normalized)}")
+    normalized = normalized + (slice(None),) * (len(shape) - len(normalized))
 
-        values = np.asarray(values)
-        if values.ndim != 1:
-            raise ValueError("Input to set_flattened must be a 1D array.")
+    selectors: list[np.ndarray] = []
+    scalar_axes: list[bool] = []
+    for axis_value, axis_size in zip(normalized, shape):
+        selector, scalar = _normalize_axis_index(axis_value, axis_size)
+        selectors.append(selector)
+        scalar_axes.append(scalar)
+    return selectors, scalar_axes
 
-        expected = self.flatten().shape[0]
-        if values.shape[0] != expected:
-            raise ValueError(f"Expected {expected} values, got {values.shape[0]}")
 
-        fill(self.vector._data, values, cursor=0)
+def _expand_ellipsis(idx: tuple[Any, ...], ndim: int) -> tuple[Any, ...]:
+    if not any(item is Ellipsis for item in idx):
+        return idx
+    if sum(item is Ellipsis for item in idx) > 1:
+        raise IndexError("Only one ellipsis is allowed.")
+    ellipsis_pos = next(i for i, item in enumerate(idx) if item is Ellipsis)
+    fill = ndim - (len(idx) - 1)
+    return idx[:ellipsis_pos] + (slice(None),) * fill + idx[ellipsis_pos + 1 :]
 
-    def __getitem__(
-        self, idx: Union[Tuple[Union[int, slice], ...], int, slice]
-    ) -> Union[NDArray, "_FieldView"]:
-        # Optionally allow v['field0'][0, 1] to get subregion, or v['field0'][...] slice
-        sub = self.vector[idx]
-        if isinstance(sub, Vector):
-            return sub[self.field_name]
-        elif isinstance(sub, np.ndarray):
-            return sub[:, self.field_index]
-        return cast(NDArray, None)
 
-    def __array__(self) -> np.ndarray:
-        """Convert to numpy array when needed."""
-        return self.flatten()
+def _normalize_axis_index(value: Any, axis_size: int) -> tuple[np.ndarray, bool]:
+    if isinstance(value, (int, np.integer)):
+        index = int(value)
+        if index < 0:
+            index += axis_size
+        if index < 0 or index >= axis_size:
+            raise IndexError(f"Index {value} out of bounds for axis with size {axis_size}")
+        return np.array([index], dtype=int), True
+
+    if isinstance(value, slice):
+        return np.arange(axis_size)[value], False
+
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        return _normalize_axis_index(value.item(), axis_size)
+
+    array = np.asarray(value)
+    if array.ndim != 1:
+        raise IndexError("Only 1D per-axis fancy or boolean indexing is supported.")
+    if array.size == 0:
+        return np.array([], dtype=int), False
+
+    if array.dtype == bool or np.issubdtype(array.dtype, np.bool_):
+        if array.shape[0] != axis_size:
+            raise IndexError(
+                f"Boolean mask length {array.shape[0]} does not match axis size {axis_size}"
+            )
+        return np.flatnonzero(array), False
+
+    if not np.issubdtype(array.dtype, np.integer):
+        raise TypeError(f"Unsupported index type {type(value).__name__}")
+
+    normalized = array.astype(int, copy=True)
+    normalized[normalized < 0] += axis_size
+    if np.any((normalized < 0) | (normalized >= axis_size)):
+        raise IndexError(f"Index out of bounds for axis with size {axis_size}")
+    return normalized, False
+
+
+def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
+    if not isinstance(data, list):
+        raise TypeError("Data must be a list.")
+    if not data:
+        raise ValueError("Data list cannot be empty.")
+
+    leaves: list[NDArray[np.generic]] = []
+    num_fields: int | None = None
+
+    def walk(node: Any) -> tuple[int, ...]:
+        nonlocal num_fields
+        if _is_leaf_cell(node):
+            array = np.asarray(node)
+            if array.ndim != 2:
+                raise ValueError(f"Cell arrays must be 2D, got shape {array.shape}")
+            if not np.issubdtype(array.dtype, np.number):
+                raise TypeError("Cell arrays must contain numeric values.")
+            if num_fields is None:
+                num_fields = array.shape[1]
+            elif array.shape[1] != num_fields:
+                raise ValueError("All data arrays must have same number of fields.")
+            leaves.append(array)
+            return ()
+
+        if not isinstance(node, list):
+            raise TypeError("Data elements must be numpy arrays, numeric 2D lists, or nested lists thereof.")
+        if not node:
+            raise ValueError("Nested data lists cannot be empty.")
+        child_shapes = [walk(child) for child in node]
+        first = child_shapes[0]
+        if any(shape != first for shape in child_shapes[1:]):
+            raise ValueError("Nested data structure must have a consistent fixed-grid shape.")
+        return (len(node), *first)
+
+    inferred_shape = walk(data)
+    return inferred_shape, leaves
+
+
+def _is_leaf_cell(node: Any) -> bool:
+    if isinstance(node, np.ndarray):
+        return True
+    if not isinstance(node, list):
+        return False
+    try:
+        array = np.asarray(node)
+    except Exception:
+        return False
+    return array.ndim == 2 and np.issubdtype(array.dtype, np.number)

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -241,7 +241,7 @@ class Vector(AutoSerialize):
     @property
     def units(self) -> list[str]:
         """Return units for the selected fields."""
-        lookup = {field: unit for field, unit in zip(self._state["fields"], self._state["units"])}
+        lookup = dict(zip(self._state["fields"], self._state["units"]))
         return [lookup[field] for field in self.fields]
 
     @property
@@ -338,10 +338,7 @@ class Vector(AutoSerialize):
         if missing:
             raise KeyError(f"Unknown field(s): {missing}")
 
-        if selected == tuple(self._state["fields"]):
-            selected_fields = None
-        else:
-            selected_fields = selected
+        selected_fields = None if selected == tuple(self._state["fields"]) else selected
         return self._from_view(
             self._state,
             self.shape,
@@ -782,8 +779,6 @@ class Vector(AutoSerialize):
         """Return the full backing matrix for one cell."""
         start = int(self._state["cell_starts"][linear_index])
         length = int(self._state["cell_lengths"][linear_index])
-        if length == 0:
-            return self._state["data"][0:0]
         return self._state["data"][start : start + length]
 
     def _selected_cell_matrix(self, linear_index: int) -> NDArray[Any]:
@@ -817,11 +812,7 @@ class Vector(AutoSerialize):
         payloads = [array for array in normalized if array.shape[0] > 0]
         if payloads:
             appended = np.vstack(payloads)
-            data = self._state["data"]
-            if data.shape[0] == 0:
-                self._state["data"] = appended.copy()
-            else:
-                self._state["data"] = np.concatenate((data, appended), axis=0)
+            self._state["data"] = np.concatenate((self._state["data"], appended), axis=0)
 
         cursor = self._state["data"].shape[0] - sum(array.shape[0] for array in normalized)
         for target, array in zip(targets, normalized):
@@ -846,9 +837,7 @@ class Vector(AutoSerialize):
         """Compact automatically once dead rows become materially larger than live rows."""
         data = self._state["data"]
         used_rows = int(self._state["cell_lengths"].sum())
-        if data.shape[0] <= used_rows + 1024:
-            return
-        if data.shape[0] <= 2 * used_rows:
+        if data.shape[0] <= used_rows + 1024 or data.shape[0] <= 2 * used_rows:
             return
         self.compact()
 

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Sequence
+from pathlib import Path
+from typing import Any, Literal, Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -899,6 +900,46 @@ class Vector(AutoSerialize):
             if rows > 0:
                 cell[:, field_indices] = op(chunk, lhs) if reverse else op(lhs, chunk)
             cursor += rows
+
+    def save(
+        self,
+        path: str | Path,
+        mode: Literal["w", "o"] = "w",
+        store: Literal["auto", "zip", "dir"] = "auto",
+        skip: str | type | Sequence[str | type] = (),
+        compression_level: int | None = 4,
+    ) -> None:
+        """
+        Save the Vector object to disk using Zarr serialization. self.compact() is called before
+        saving to reduce file size if possible.
+
+        Parameters
+        ----------
+        path : str or Path
+            Target file path. Use '.zip' extension for zip format, otherwise a directory.
+        mode : {'w', 'o'}
+            'w' = write only if file doesn't exist, 'o' = overwrite if it does.
+        store : {'auto', 'zip', 'dir'}
+            Storage format. 'auto' infers from file extension.
+        skip : str, type, or list of (str or type)
+            Attribute names/types to skip (by name or type) during serialization.
+        compression_level : int or None
+            If set (0–9), applies Zstandard compression with Blosc backend at that level.
+            Level 0 disables compression. Raises ValueError if > 9.
+
+        Notes
+        -----
+        Skipped attribute names and types are also stored in the file metadata for correct
+        round-trip skipping during load().
+        """
+        self.compact()
+        super().save(
+            path,
+            mode=mode,
+            store=store,
+            skip=skip,
+            compression_level=compression_level,
+        )
 
 
 def _resolve_fields(

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -240,6 +240,7 @@ class Vector(AutoSerialize):
         values: Any | None = None,
         units: str | Sequence[str] | None = None,
     ) -> None:
+        self._require_full_field_view("add_fields")
         new_fields = _normalize_field_names(names)
         if any(field in self._state["fields"] for field in new_fields):
             raise ValueError("One or more new field names already exist.")
@@ -264,6 +265,7 @@ class Vector(AutoSerialize):
             self._selected_fields = None
 
     def remove_fields(self, names: str | Sequence[str]) -> None:
+        self._require_full_field_view("remove_fields")
         to_remove = set(_normalize_field_names(names))
         old_fields = self._state["fields"]
         old_units = self._state["units"]
@@ -378,6 +380,10 @@ class Vector(AutoSerialize):
             return np.array([lookup[field] for field in self._selected_fields], dtype=np.int64)
         except KeyError as exc:
             raise KeyError(f"Unknown field(s): {[str(exc.args[0])]}") from exc
+
+    def _require_full_field_view(self, operation: str) -> None:
+        if self._selected_fields is not None:
+            raise ValueError(f"{operation} is only allowed when all fields are selected.")
 
     def _selected_cell_indices(self) -> NDArray[np.int64]:
         if self._selection_indices is None:

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -18,10 +18,75 @@ from quantem.core.utils.validators import (
 class Vector(AutoSerialize):
     """Ragged cell data on a fixed grid.
 
-    Storage is compact and AutoSerialize-friendly:
-    - one 2D numeric row buffer for all ragged rows
-    - one start array and one length array for cell boundaries
-    - optional selection state for views
+    A ``Vector`` has two independent axes of structure:
+    - fixed-grid dimensions given by ``shape``
+    - ragged rows stored inside each fixed-grid cell
+
+    Each ragged row has one value per named field, so each cell behaves like a
+    small 2D array with shape ``(n_rows, num_fields)``, where ``n_rows`` may
+    vary from cell to cell.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Fixed-grid shape.
+    fields : sequence of str
+        Field names in column order.
+    units : sequence of str, optional
+        Units corresponding to ``fields``. If omitted, units default to
+        ``"none"`` for all fields.
+    name : str, optional
+        Descriptive name for the Vector.
+    metadata : dict, optional
+        Additional user metadata.
+
+    Notes
+    -----
+    The public API keeps fixed-grid indexing and field selection separate:
+    - use ``[]`` for fixed-grid indexing
+    - use ``select_fields(...)`` for field selection
+
+    Fixed-grid indexing always returns a ``Vector``. A 0D selection exposes its
+    underlying cell array through ``.array``. Multi-cell selections can be
+    concatenated with ``flatten()``.
+
+    The internal representation is compact:
+    - ``_state["data"]`` stores all ragged rows in one numeric 2D array
+    - ``_state["cell_starts"]`` stores the start offset for each cell
+    - ``_state["cell_lengths"]`` stores the row count for each cell
+
+    A ``Vector`` selection is a write-through view over shared storage. Views
+    track only the selected fixed-grid shape, selected cell indices, and selected
+    field names.
+
+    Examples
+    --------
+    Create a Vector and assign one cell:
+
+    >>> import numpy as np
+    >>> v = Vector.from_shape((2, 2), fields=("kx", "ky", "intensity"))
+    >>> v[0, 0] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> v[0, 0].array.shape
+    (2, 3)
+
+    Select fields and apply in-place arithmetic:
+
+    >>> kx = v.select_fields("kx")
+    >>> kx += 16
+    >>> kx.flatten().shape
+    (2, 1)
+
+    Apply a rowwise transform with ``flatten()`` and ``set_flattened()``:
+
+    >>> kx = v.select_fields("kx")
+    >>> ky = v.select_fields("ky")
+    >>> kx.set_flattened(
+    ...     np.where(
+    ...         ((kx.flatten() - 16) ** 2 + (ky.flatten() - 16) ** 2) < 12,
+    ...         10,
+    ...         kx.flatten(),
+    ...     )
+    ... )
     """
 
     def __init__(
@@ -61,6 +126,7 @@ class Vector(AutoSerialize):
         selection_indices: NDArray[np.int64] | None,
         selected_fields: tuple[str, ...] | None,
     ) -> "Vector":
+        """Build a view that shares backing storage with another Vector."""
         obj = cls.__new__(cls)
         obj._state = state
         obj._selection_shape = selection_shape
@@ -77,6 +143,7 @@ class Vector(AutoSerialize):
         units: Sequence[str] | None = None,
         name: str | None = None,
     ) -> "Vector":
+        """Create an empty Vector with the given fixed-grid shape and fields."""
         if fields is not None:
             root_fields = validate_fields(list(fields))
             if num_fields is not None and len(root_fields) != num_fields:
@@ -100,6 +167,11 @@ class Vector(AutoSerialize):
         units: Sequence[str] | None = None,
         name: str | None = None,
     ) -> "Vector":
+        """Create a Vector from nested fixed-grid data.
+
+        The outer nesting defines the fixed-grid shape. Each leaf must coerce to a
+        2D cell array with consistent field count across all cells.
+        """
         root_shape, cell_arrays = _normalize_nested_data(data)
         inferred_counts = {array.shape[1] for array in cell_arrays}
         if len(inferred_counts) > 1:
@@ -128,16 +200,19 @@ class Vector(AutoSerialize):
 
     @property
     def shape(self) -> tuple[int, ...]:
+        """Return the fixed-grid shape of this selection."""
         return self._selection_shape
 
     @property
     def fields(self) -> list[str]:
+        """Return selected field names in column order."""
         if self._selected_fields is None:
             return list(self._state["fields"])
         return list(self._selected_fields)
 
     @property
     def units(self) -> list[str]:
+        """Return units for the selected fields."""
         lookup = {
             field: unit
             for field, unit in zip(self._state["fields"], self._state["units"])
@@ -146,10 +221,12 @@ class Vector(AutoSerialize):
 
     @property
     def num_fields(self) -> int:
+        """Return the number of selected fields."""
         return len(self.fields)
 
     @property
     def name(self) -> str:
+        """Human-readable Vector name."""
         return self._state["name"]
 
     @name.setter
@@ -158,10 +235,18 @@ class Vector(AutoSerialize):
 
     @property
     def metadata(self) -> dict[str, Any]:
+        """Mutable metadata dictionary shared by all views."""
         return self._state["metadata"]
 
     @property
     def array(self) -> NDArray[np.generic]:
+        """Return the selected cell as a NumPy array.
+
+        This is only valid for 0D selections. Single-field and contiguous
+        multi-field selections return writable views into the backing storage.
+        Non-contiguous multi-field selections return a copy because NumPy cannot
+        expose a writable column-subset view for that layout.
+        """
         if self.shape != ():
             raise ValueError(".array is only valid when the selection contains exactly one cell.")
         cell = self._cell_matrix(self._selected_cell_indices()[0])
@@ -176,6 +261,7 @@ class Vector(AutoSerialize):
         return cell[:, cols].copy()
 
     def __len__(self) -> int:
+        """Return ``shape[0]`` for non-scalar selections."""
         if self.shape == ():
             raise TypeError("len() of unsized 0D Vector")
         return self.shape[0]
@@ -192,6 +278,7 @@ class Vector(AutoSerialize):
     __str__ = __repr__
 
     def copy(self) -> "Vector":
+        """Return a deep copy of the current selection."""
         copied = self.__class__(
             shape=self.shape,
             fields=self.fields,
@@ -205,6 +292,11 @@ class Vector(AutoSerialize):
         return copied
 
     def flatten(self) -> NDArray[np.generic]:
+        """Concatenate selected cells in row-major order.
+
+        Returns a 2D array with shape ``(total_rows, num_fields)`` even for
+        single-field selections.
+        """
         arrays = [
             self._selected_cell_matrix(index)
             for index in self._selected_cell_indices()
@@ -216,8 +308,24 @@ class Vector(AutoSerialize):
         dtype = self._state["data"].dtype if self._state["data"].ndim == 2 else float
         return np.empty((0, self.num_fields), dtype=dtype)
 
-    def select_fields(self, field_names: str | Sequence[str]) -> "Vector":
-        selected = _normalize_field_names(field_names)
+    @property
+    def total_rows(self) -> int:
+        """Return the total ragged-row count in the current selection."""
+        return int(self._state["cell_lengths"][self._selected_cell_indices()].sum())
+
+    def row_counts(self) -> list[int]:
+        """Return per-cell row counts in the current selection order."""
+        return [self._cell_row_count(int(index)) for index in self._selected_cell_indices()]
+
+    def select_fields(self, *field_names: str | Sequence[str]) -> "Vector":
+        """Return a view containing only the requested fields.
+
+        Accepted forms:
+        - ``select_fields("kx")``
+        - ``select_fields("kx", "ky")``
+        - ``select_fields(["kx", "ky"])``
+        """
+        selected = _normalize_select_field_args(*field_names)
         available = set(self.fields)
         missing = [field for field in selected if field not in available]
         if missing:
@@ -234,12 +342,71 @@ class Vector(AutoSerialize):
             selected_fields,
         )
 
+    def set_flattened(self, values: Any) -> None:
+        """Write values back in flattened row-major order.
+
+        This updates existing rows without changing per-cell row counts. It is
+        the rowwise companion to ``flatten()`` and is especially useful for
+        NumPy-based transforms that operate on all selected rows at once.
+        """
+        field_indices = self._field_indices()
+        targets = self._selected_cell_indices()
+        row_counts = self.row_counts()
+        total_rows = sum(row_counts)
+
+        if isinstance(values, Vector):
+            if values.num_fields != self.num_fields:
+                raise ValueError(f"Expected {self.num_fields} fields, got {values.num_fields}")
+            flat_values = values.flatten()
+            if flat_values.shape[0] != total_rows:
+                raise ValueError(f"Expected {total_rows} rows, got {flat_values.shape[0]}")
+        else:
+            flat_values = _broadcast_field_values(values, total_rows, self.num_fields)
+
+        cursor = 0
+        for target, rows in zip(targets, row_counts):
+            cell = self._cell_matrix(int(target))
+            if rows > 0:
+                cell[:, field_indices] = flat_values[cursor : cursor + rows]
+            cursor += rows
+
+    def compact(self) -> None:
+        """Repack the backing row buffer to remove dead rows.
+
+        Whole-cell replacement appends new rows and leaves previous rows unused
+        until compaction. Calling ``compact()`` makes memory usage and save size
+        predictable at the cost of reallocating the backing buffer.
+        """
+        self._compact_storage()
+
+    def append_rows(self, idx: Any, rows: Any) -> None:
+        """Append one or more rows to a single selected cell.
+
+        ``idx`` is interpreted with the same fixed-grid indexing rules as
+        ``__getitem__`` and must resolve to exactly one cell. Appending rows is a
+        full-cell operation, so all fields must be selected.
+        """
+        target = self[idx]
+        if target.shape != ():
+            raise ValueError("append_rows requires an index that selects exactly one cell.")
+        target._require_full_field_view("append_rows")
+
+        new_rows = _coerce_cell_array(rows, target.num_fields)
+        if new_rows.shape[0] == 0:
+            return
+
+        cell_index = int(target._selected_cell_indices()[0])
+        existing = target._cell_matrix(cell_index)
+        combined = np.vstack((existing, new_rows)) if existing.shape[0] > 0 else new_rows.copy()
+        target._replace_cells(np.array([cell_index], dtype=np.int64), [combined])
+
     def add_fields(
         self,
         names: str | Sequence[str],
         values: Any | None = None,
         units: str | Sequence[str] | None = None,
     ) -> None:
+        """Add one or more new fields to the full Vector schema."""
         self._require_full_field_view("add_fields")
         new_fields = _normalize_field_names(names)
         if any(field in self._state["fields"] for field in new_fields):
@@ -254,7 +421,7 @@ class Vector(AutoSerialize):
         if values is None:
             return
 
-        target = self.select_fields(list(new_fields))
+        target = self.select_fields(*new_fields)
         if len(new_fields) > 1 and isinstance(values, (list, tuple)) and len(values) == len(new_fields):
             for field, value in zip(new_fields, values):
                 target.select_fields(field)[...] = value
@@ -265,6 +432,7 @@ class Vector(AutoSerialize):
             self._selected_fields = None
 
     def remove_fields(self, names: str | Sequence[str]) -> None:
+        """Remove one or more fields from the full Vector schema."""
         self._require_full_field_view("remove_fields")
         to_remove = set(_normalize_field_names(names))
         old_fields = self._state["fields"]
@@ -286,23 +454,11 @@ class Vector(AutoSerialize):
             if len(self._selected_fields) == len(self._state["fields"]):
                 self._selected_fields = None
 
-    def get_data(self, *indices: Any) -> NDArray[np.generic] | list[NDArray[np.generic]]:
-        if len(indices) != len(self.shape):
-            raise ValueError(f"Expected {len(self.shape)} indices, got {len(indices)}")
-        selection = self[indices if len(indices) != 1 else indices[0]]
-        if selection.shape == ():
-            return selection.array
-        return [selection._selected_cell_matrix(index).copy() for index in selection._selected_cell_indices()]
-
-    def set_data(self, value: Any, *indices: Any) -> None:
-        if len(indices) != len(self.shape):
-            raise ValueError(f"Expected {len(self.shape)} indices, got {len(indices)}")
-        self[indices if len(indices) != 1 else indices[0]] = value
-
     @overload
     def __getitem__(self, idx: Any) -> "Vector": ...
 
     def __getitem__(self, idx: Any) -> "Vector":
+        """Return a fixed-grid selection as another Vector view."""
         if _looks_like_field_selector(idx):
             raise TypeError("Use select_fields(...) for field selection.")
         if idx is Ellipsis:
@@ -321,6 +477,7 @@ class Vector(AutoSerialize):
         )
 
     def __setitem__(self, idx: Any, value: Any) -> None:
+        """Assign to a fixed-grid selection."""
         if idx is Ellipsis:
             target = self
         else:
@@ -372,6 +529,7 @@ class Vector(AutoSerialize):
         return len(self._state["fields"])
 
     def _field_indices(self) -> NDArray[np.int64]:
+        """Map selected field names to column indices in the backing buffer."""
         if self._selected_fields is None:
             return np.arange(self._full_num_fields, dtype=np.int64)
 
@@ -382,10 +540,12 @@ class Vector(AutoSerialize):
             raise KeyError(f"Unknown field(s): {[str(exc.args[0])]}") from exc
 
     def _require_full_field_view(self, operation: str) -> None:
+        """Raise if a schema-changing/full-row operation is attempted on a field view."""
         if self._selected_fields is not None:
             raise ValueError(f"{operation} is only allowed when all fields are selected.")
 
     def _selected_cell_indices(self) -> NDArray[np.int64]:
+        """Return linear cell indices for the current fixed-grid selection."""
         if self._selection_indices is None:
             return np.arange(_cell_count(self._state["shape"]), dtype=np.int64)
         return self._selection_indices
@@ -394,9 +554,11 @@ class Vector(AutoSerialize):
         return self._selected_fields is None
 
     def _cell_row_count(self, linear_index: int) -> int:
+        """Return the row count for one cell in the backing buffer."""
         return int(self._state["cell_lengths"][linear_index])
 
     def _cell_matrix(self, linear_index: int) -> NDArray[np.generic]:
+        """Return the full backing matrix for one cell."""
         start = int(self._state["cell_starts"][linear_index])
         length = int(self._state["cell_lengths"][linear_index])
         if length == 0:
@@ -404,6 +566,7 @@ class Vector(AutoSerialize):
         return self._state["data"][start : start + length]
 
     def _selected_cell_matrix(self, linear_index: int) -> NDArray[np.generic]:
+        """Return one cell with the current field selection applied."""
         cell = self._cell_matrix(linear_index)
         cols = self._field_indices()
         if cols.size == self._full_num_fields:
@@ -416,6 +579,14 @@ class Vector(AutoSerialize):
         return cell[:, cols].copy()
 
     def _replace_cells(self, targets: NDArray[np.int64], arrays: Sequence[NDArray[np.generic]]) -> None:
+        """Replace complete cells in the compact row buffer.
+
+        Whole-cell replacement is implemented by appending the new payload rows to
+        the end of the backing buffer and then updating ``cell_starts`` /
+        ``cell_lengths`` for the targeted cells. This keeps the operation simple
+        and makes overlapping assignment semantics easy to reason about, but it
+        leaves the previous rows unreachable until compaction removes them.
+        """
         if len(targets) != len(arrays):
             raise ValueError("Target cell count does not match source cell count.")
         if len(targets) == 0:
@@ -440,6 +611,7 @@ class Vector(AutoSerialize):
         self._maybe_compact_storage()
 
     def _expand_storage(self, num_new_fields: int) -> None:
+        """Append new ``np.nan``-initialized columns for added fields."""
         data = self._state["data"]
         if data.shape[0] == 0:
             dtype = np.result_type(data.dtype, float)
@@ -451,15 +623,22 @@ class Vector(AutoSerialize):
         self._state["data"] = np.concatenate((data.astype(dtype, copy=False), filler), axis=1)
 
     def _maybe_compact_storage(self) -> None:
+        """Compact automatically once dead rows become materially larger than live rows."""
         data = self._state["data"]
         used_rows = int(self._state["cell_lengths"].sum())
         if data.shape[0] <= used_rows + 1024:
             return
+        if data.shape[0] <= 2 * used_rows:
+            return
+        self._compact_storage()
+
+    def _compact_storage(self) -> None:
+        """Rebuild the row buffer so only live rows remain."""
+        data = self._state["data"]
+        used_rows = int(self._state["cell_lengths"].sum())
         if used_rows == 0:
             self._state["data"] = np.empty((0, self._full_num_fields), dtype=data.dtype)
             self._state["cell_starts"].fill(0)
-            return
-        if data.shape[0] <= 2 * used_rows:
             return
 
         compacted = np.empty((used_rows, self._full_num_fields), dtype=data.dtype)
@@ -476,12 +655,18 @@ class Vector(AutoSerialize):
         self._state["cell_starts"] = starts
 
     def _assign(self, value: Any) -> None:
+        """Dispatch assignment based on whether all fields or a subset are selected."""
         if self._is_full_field_selection():
             self._assign_full_cells(value)
         else:
             self._assign_selected_fields(value)
 
     def _assign_full_cells(self, value: Any) -> None:
+        """Replace full cell payloads.
+
+        Full-cell assignment may change the ragged row count of each targeted
+        cell, because the existing cell matrix is replaced as a whole.
+        """
         targets = self._selected_cell_indices()
         if isinstance(value, Vector):
             source_cells = value._selected_cell_indices()
@@ -499,6 +684,13 @@ class Vector(AutoSerialize):
         self._replace_cells(targets, [array] * len(targets))
 
     def _assign_selected_fields(self, value: Any) -> None:
+        """Update only the selected columns while preserving row counts.
+
+        This is the in-place path for assignments such as
+        ``vector.select_fields("kx")[...] = rhs``. The target cell structure is
+        preserved, so each target cell keeps its existing row count and only the
+        selected columns are overwritten.
+        """
         targets = self._selected_cell_indices()
         field_indices = self._field_indices()
         row_counts = [self._cell_row_count(index) for index in targets]
@@ -539,11 +731,13 @@ class Vector(AutoSerialize):
             cursor += rows
 
     def _binary_op(self, other: Any, op: Any, reverse: bool = False) -> "Vector":
+        """Return a new Vector produced by elementwise arithmetic."""
         result = self.copy()
         result._inplace_op(other, op, reverse=reverse)
         return result
 
     def _inplace_op(self, other: Any, op: Any, reverse: bool = False) -> None:
+        """Apply elementwise arithmetic in-place to the selected fields."""
         targets = self._selected_cell_indices()
         field_indices = self._field_indices()
         row_counts = [self._cell_row_count(index) for index in targets]
@@ -585,10 +779,12 @@ class Vector(AutoSerialize):
 
 
 def _cell_count(shape: tuple[int, ...]) -> int:
+    """Return the number of fixed-grid cells in a shape."""
     return int(np.prod(shape, dtype=np.int64)) if shape else 1
 
 
 def _normalize_field_names(field_names: str | Sequence[str]) -> tuple[str, ...]:
+    """Normalize one-or-many field names into a validated tuple."""
     if isinstance(field_names, str):
         normalized = (field_names,)
     else:
@@ -599,8 +795,25 @@ def _normalize_field_names(field_names: str | Sequence[str]) -> tuple[str, ...]:
     return normalized
 
 
+def _normalize_select_field_args(*field_names: str | Sequence[str]) -> tuple[str, ...]:
+    """Normalize ``select_fields`` arguments.
+
+    This accepts either ``select_fields("a", "b")`` or
+    ``select_fields(["a", "b"])`` while keeping ``add_fields`` /
+    ``remove_fields`` on the simpler single-argument path.
+    """
+    if not field_names:
+        raise ValueError("At least one field name is required.")
+    if len(field_names) == 1 and not isinstance(field_names[0], str):
+        return _normalize_field_names(field_names[0])
+    if not all(isinstance(name, str) for name in field_names):
+        raise TypeError("select_fields(...) expects field names as strings or one sequence of strings.")
+    return _normalize_field_names(field_names)
+
+
 
 def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]:
+    """Normalize field units to a list matching ``count``."""
     if units is None:
         return ["none"] * count
     if isinstance(units, str):
@@ -615,6 +828,7 @@ def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]
 
 
 def _looks_like_field_selector(idx: Any) -> bool:
+    """Return True for indices that look like field selection by mistake."""
     if isinstance(idx, str):
         return True
     if isinstance(idx, tuple) and any(_looks_like_field_selector(item) for item in idx):
@@ -626,6 +840,7 @@ def _looks_like_field_selector(idx: Any) -> bool:
 
 
 def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
+    """Normalize a single-cell payload to shape ``(n_rows, num_fields)``."""
     if isinstance(value, Vector):
         if value.shape != ():
             raise ValueError("Expected a 0D Vector for single-cell assignment.")
@@ -651,6 +866,7 @@ def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
 
 
 def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
+    """Normalize nested input data into ``(shape, flat_cell_arrays)``."""
     if not isinstance(data, list):
         raise TypeError("Data must be a list")
     if not data:
@@ -660,6 +876,7 @@ def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArr
 
 
 def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
+    """Recursively flatten nested fixed-grid input into row-major cell order."""
     if isinstance(node, np.ndarray):
         return (), [_coerce_inferred_cell_array(node)]
     if not isinstance(node, (list, tuple)):
@@ -685,6 +902,7 @@ def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.gen
 
 
 def _looks_like_cell_rows(node: Sequence[Any]) -> bool:
+    """Return True when a sequence should be interpreted as cell rows, not grid nesting."""
     if len(node) == 0:
         return True
     return all(_is_row_like(item) for item in node)
@@ -692,6 +910,7 @@ def _looks_like_cell_rows(node: Sequence[Any]) -> bool:
 
 
 def _is_row_like(item: Any) -> bool:
+    """Return True for a single row of scalar values."""
     if isinstance(item, np.ndarray):
         return item.ndim == 1
     if not isinstance(item, (list, tuple)):
@@ -701,6 +920,7 @@ def _is_row_like(item: Any) -> bool:
 
 
 def _coerce_inferred_cell_array(value: Any) -> NDArray[np.generic]:
+    """Infer a 2D cell array from row-like input during ``from_data``."""
     array = np.asarray(value)
     if array.ndim == 0:
         raise ValueError("Cell data must be 1D or 2D.")
@@ -719,6 +939,14 @@ def _select_linear_indices(
     current_indices: NDArray[np.int64],
     idx: Any,
 ) -> tuple[tuple[int, ...], NDArray[np.int64]]:
+    """Apply fixed-grid indexing to a flattened cell-index view.
+
+    ``current_indices`` stores the linear cell indices represented by the current
+    selection. This helper reshapes those indices to the current selection shape,
+    applies NumPy-like indexing on the fixed-grid axes, and then returns:
+    - the output fixed-grid shape
+    - the flattened linear indices of the selected cells, in row-major order
+    """
     if shape == ():
         if idx in ((), Ellipsis):
             return (), np.array([int(current_indices[0])], dtype=np.int64)
@@ -750,6 +978,7 @@ def _select_linear_indices(
 
 
 def _normalize_index_tuple(idx: Any, ndim: int) -> tuple[Any, ...]:
+    """Normalize fixed-grid indexing to a full ``ndim``-length tuple."""
     if idx is Ellipsis:
         return (slice(None),) * ndim
     if not isinstance(idx, tuple):
@@ -771,6 +1000,7 @@ def _normalize_index_tuple(idx: Any, ndim: int) -> tuple[Any, ...]:
 
 
 def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], bool]:
+    """Resolve one axis index into concrete positions and scalar-vs-vector shape behavior."""
     if isinstance(axis_index, (bool, np.bool_)):
         raise TypeError("Boolean scalars are not valid Vector indices.")
 
@@ -814,6 +1044,7 @@ def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], 
 
 
 def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDArray[np.generic]:
+    """Broadcast array-like input to flattened rowwise assignment shape."""
     array = np.asarray(value)
     if array.ndim == 0:
         return np.broadcast_to(array.reshape(1, 1), (total_rows, num_fields))
@@ -833,6 +1064,7 @@ def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDA
 
 
 def _is_contiguous(indices: NDArray[np.int64]) -> bool:
+    """Return True when integer column indices form one contiguous slice."""
     if indices.size <= 1:
         return True
     return bool(np.all(indices[1:] - indices[:-1] == 1))

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -473,6 +473,30 @@ class Vector(AutoSerialize):
         if self._selected_fields is not None and tuple(old_fields) == self._selected_fields:
             self._selected_fields = None
 
+    def rename_fields(self, mapping: dict[str, str]) -> None:
+        """Rename one or more fields in-place.
+
+        Parameters
+        ----------
+        mapping : dict
+            Maps each old field name to its new name, e.g.
+            ``{"kx": "qx", "ky": "qy"}``.
+        """
+        old_field_set = set(self._state["fields"])
+        missing = [old for old in mapping if old not in old_field_set]
+        if missing:
+            raise KeyError(f"Unknown field(s): {missing}")
+        new_names = list(mapping.values())
+        conflicts = [n for n in new_names if n in old_field_set and n not in mapping]
+        if conflicts:
+            raise ValueError(f"New field name(s) already exist: {conflicts}")
+        validate_fields(new_names)
+
+        rename = {old: new for old, new in mapping.items()}
+        self._state["fields"] = [rename.get(f, f) for f in self._state["fields"]]
+        if self._selected_fields is not None:
+            self._selected_fields = tuple(rename.get(f, f) for f in self._selected_fields)
+
     def remove_fields(self, names: str | Sequence[str]) -> None:
         """Remove one or more fields from the full Vector schema."""
         self._require_full_field_view("remove_fields")

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -89,6 +89,8 @@ class Vector(AutoSerialize):
     ... )
     """
 
+    __array_priority__ = 1000
+
     def __init__(
         self,
         shape: tuple[int, ...],
@@ -494,6 +496,39 @@ class Vector(AutoSerialize):
             target = self[idx]
         target._assign(value)
 
+    def __array_ufunc__(self, ufunc: Any, method: str, *inputs: Any, **kwargs: Any) -> Any:
+        """Apply supported NumPy ufuncs elementwise.
+
+        Supported operations are limited to elementwise ``__call__`` ufuncs. The
+        result preserves the current selection shape and fields.
+        """
+        if method != "__call__":
+            return NotImplemented
+
+        out = kwargs.get("out")
+        if out is not None:
+            return NotImplemented
+
+        vector_inputs = [value for value in inputs if isinstance(value, Vector)]
+        if not vector_inputs:
+            return NotImplemented
+
+        template = vector_inputs[0]
+        row_counts = template.row_counts()
+        total_rows = sum(row_counts)
+
+        for other in vector_inputs[1:]:
+            if other.shape != template.shape:
+                raise ValueError("Vector ufunc inputs must have matching fixed-grid shapes.")
+            if other.num_fields != template.num_fields:
+                raise ValueError("Vector ufunc inputs must have matching field counts.")
+            if other.row_counts() != row_counts:
+                raise ValueError("Vector ufunc inputs must have matching per-cell row counts.")
+
+        flat_inputs = [_normalize_ufunc_input(value, total_rows, template.num_fields) for value in inputs]
+        result = ufunc(*flat_inputs, **kwargs)
+        return _wrap_ufunc_result(template, result, row_counts)
+
     def __add__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.add)
 
@@ -506,6 +541,15 @@ class Vector(AutoSerialize):
     def __truediv__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.divide)
 
+    def __floordiv__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.floor_divide)
+
+    def __mod__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.mod)
+
+    def __pow__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.power)
+
     def __radd__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.add, reverse=True)
 
@@ -517,6 +561,15 @@ class Vector(AutoSerialize):
 
     def __rtruediv__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.divide, reverse=True)
+
+    def __rfloordiv__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.floor_divide, reverse=True)
+
+    def __rmod__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.mod, reverse=True)
+
+    def __rpow__(self, other: Any) -> "Vector":
+        return self._binary_op(other, np.power, reverse=True)
 
     def __iadd__(self, other: Any) -> "Vector":
         self._inplace_op(other, np.add)
@@ -533,6 +586,29 @@ class Vector(AutoSerialize):
     def __itruediv__(self, other: Any) -> "Vector":
         self._inplace_op(other, np.divide)
         return self
+
+    def __ifloordiv__(self, other: Any) -> "Vector":
+        self._inplace_op(other, np.floor_divide)
+        return self
+
+    def __imod__(self, other: Any) -> "Vector":
+        self._inplace_op(other, np.mod)
+        return self
+
+    def __ipow__(self, other: Any) -> "Vector":
+        self._inplace_op(other, np.power)
+        return self
+
+    def __neg__(self) -> "Vector":
+        return self._binary_op(-1, np.multiply)
+
+    def __pos__(self) -> "Vector":
+        return self.copy()
+
+    def __abs__(self) -> "Vector":
+        result = self.copy()
+        result._inplace_unary(np.abs)
+        return result
 
     @property
     def _full_num_fields(self) -> int:
@@ -745,6 +821,16 @@ class Vector(AutoSerialize):
         result = self.copy()
         result._inplace_op(other, op, reverse=reverse)
         return result
+
+    def _inplace_unary(self, op: Any) -> None:
+        """Apply a unary elementwise operation in-place to the selected fields."""
+        targets = self._selected_cell_indices()
+        field_indices = self._field_indices()
+        for target in targets:
+            cell = self._cell_matrix(int(target))
+            lhs = cell[:, field_indices]
+            if lhs.shape[0] > 0:
+                cell[:, field_indices] = op(lhs)
 
     def _inplace_op(self, other: Any, op: Any, reverse: bool = False) -> None:
         """Apply elementwise arithmetic in-place to the selected fields."""
@@ -1070,6 +1156,57 @@ def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDA
         raise ValueError(
             f"Cannot broadcast value with shape {array.shape} to ({total_rows}, {num_fields})"
         ) from exc
+
+
+def _normalize_ufunc_input(value: Any, total_rows: int, num_fields: int) -> Any:
+    """Normalize one ufunc input to flattened Vector-compatible form."""
+    if isinstance(value, Vector):
+        return value.flatten()
+    if np.isscalar(value):
+        return value
+    return _broadcast_field_values(value, total_rows, num_fields)
+
+
+def _wrap_ufunc_result(
+    template: Vector,
+    result: Any,
+    row_counts: list[int],
+) -> Any:
+    """Convert elementwise ufunc output back into Vector selections."""
+    if isinstance(result, tuple):
+        return tuple(_vector_from_flat_result(template, item, row_counts) for item in result)
+    return _vector_from_flat_result(template, result, row_counts)
+
+
+def _vector_from_flat_result(
+    template: Vector,
+    values: Any,
+    row_counts: list[int],
+) -> Vector:
+    """Build a Vector from flattened rowwise result data."""
+    total_rows = sum(row_counts)
+    flat_values = _broadcast_field_values(values, total_rows, template.num_fields)
+
+    result = Vector.from_shape(
+        shape=template.shape,
+        fields=template.fields,
+        units=template.units,
+        name=template.name,
+    )
+    result._state["metadata"] = copy.deepcopy(template.metadata)
+
+    if total_rows == 0:
+        result._state["data"] = np.empty((0, template.num_fields), dtype=flat_values.dtype)
+        return result
+
+    cursor = 0
+    cells: list[NDArray[np.generic]] = []
+    for rows in row_counts:
+        cells.append(flat_values[cursor : cursor + rows].copy())
+        cursor += rows
+
+    result._replace_cells(result._selected_cell_indices(), cells)
+    return result
 
 
 

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Sequence, cast
+from typing import Any, Sequence
 
 import numpy as np
 from numpy.typing import NDArray
@@ -90,6 +90,7 @@ class Vector(AutoSerialize):
     """
 
     __array_priority__ = 1000
+    _token = object()
 
     def __init__(
         self,
@@ -98,7 +99,12 @@ class Vector(AutoSerialize):
         units: Sequence[str] | None = None,
         name: str | None = None,
         metadata: dict[str, Any] | None = None,
+        _token: object | None = None,
     ) -> None:
+        if _token is not self._token:
+            raise RuntimeError(
+                "Use Vector.from_shape() or Vector.from_data() to instantiate this class."
+            )
         root_shape = validate_shape(shape)
         root_fields = validate_fields(list(fields))
         root_units = validate_vector_units(
@@ -146,59 +152,50 @@ class Vector(AutoSerialize):
         fields: Sequence[str] | None = None,
         units: Sequence[str] | None = None,
         name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> "Vector":
         """Create an empty Vector with the given fixed-grid shape and fields."""
-        if fields is not None:
-            root_fields = validate_fields(list(fields))
-            if num_fields is not None and len(root_fields) != num_fields:
-                raise ValueError(
-                    f"num_fields ({num_fields}) does not match length of fields ({len(root_fields)})"
-                )
-        elif num_fields is not None:
-            count = validate_num_fields(num_fields)
-            root_fields = [f"field_{i}" for i in range(count)]
-        else:
-            raise ValueError("Must specify either 'fields' or 'num_fields'.")
-
-        return cls(shape=shape, fields=root_fields, units=units, name=name)
+        fields = _resolve_fields(fields, num_fields, None)
+        return cls(
+            shape=shape,
+            fields=fields,
+            units=units,
+            name=name,
+            metadata=metadata,
+            _token=cls._token,
+        )
 
     @classmethod
     def from_data(
         cls,
-        data: list[Any],
+        data: Sequence[Any],
         num_fields: int | None = None,
         fields: Sequence[str] | None = None,
         units: Sequence[str] | None = None,
         name: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> "Vector":
         """Create a Vector from nested fixed-grid data.
 
         The outer nesting defines the fixed-grid shape. Each leaf must coerce to a
         2D cell array with consistent field count across all cells.
         """
-        root_shape, cell_arrays = _normalize_nested_data(data)
+        if not isinstance(data, (list, tuple)):
+            raise TypeError(f"Data must be a list or tuple, got {type(data)}")
+        root_shape, cell_arrays = _flatten_fixed_grid(data) if len(data) > 0 else ((0,), [])
         inferred_counts = {array.shape[1] for array in cell_arrays}
         if len(inferred_counts) > 1:
             raise ValueError("All cell arrays must have the same number of fields.")
         inferred_fields = cell_arrays[0].shape[1] if cell_arrays else 0
 
-        if fields is not None:
-            root_fields = validate_fields(list(fields))
-            if len(root_fields) != inferred_fields:
-                raise ValueError(
-                    f"num_fields ({inferred_fields}) does not match length of fields ({len(root_fields)})"
-                )
-        elif num_fields is not None:
-            count = validate_num_fields(num_fields)
-            if count != inferred_fields:
-                raise ValueError(
-                    f"Provided num_fields ({count}) does not match inferred ({inferred_fields})."
-                )
-            root_fields = [f"field_{i}" for i in range(count)]
-        else:
-            root_fields = [f"field_{i}" for i in range(inferred_fields)]
-
-        vector = cls(shape=root_shape, fields=root_fields, units=units, name=name)
+        vector = cls(
+            shape=root_shape,
+            fields=_resolve_fields(fields, num_fields, inferred_fields),
+            units=units,
+            name=name,
+            metadata=metadata,
+            _token=cls._token,
+        )
         vector._replace_cells(np.arange(len(cell_arrays), dtype=np.int64), cell_arrays)
         return vector
 
@@ -245,7 +242,7 @@ class Vector(AutoSerialize):
         return self._state["metadata"]
 
     @property
-    def array(self) -> NDArray[np.generic]:
+    def array(self) -> NDArray[Any]:
         """Return the selected cell as a NumPy array.
 
         This is only valid for 0D selections. Single-field and contiguous
@@ -291,6 +288,7 @@ class Vector(AutoSerialize):
             units=self.units,
             name=self.name,
             metadata=copy.deepcopy(self.metadata),
+            _token=self.__class__._token,
         )
         target_cells = copied._selected_cell_indices()
         source_arrays = [
@@ -299,7 +297,7 @@ class Vector(AutoSerialize):
         copied._replace_cells(target_cells, source_arrays)
         return copied
 
-    def flatten(self) -> NDArray[np.generic]:
+    def flatten(self) -> NDArray[Any]:
         """Concatenate selected cells in row-major order.
 
         Returns a 2D array with shape ``(total_rows, num_fields)`` even for
@@ -338,7 +336,16 @@ class Vector(AutoSerialize):
         - ``select_fields("kx", "ky")``
         - ``select_fields(["kx", "ky"])``
         """
-        selected = _normalize_select_field_args(*field_names)
+        if not field_names:
+            raise ValueError("At least one field name is required.")
+        if len(field_names) == 1 and not isinstance(field_names[0], str):
+            selected = _normalize_field_names(field_names[0])
+        elif not all(isinstance(n, str) for n in field_names):
+            raise TypeError(
+                "select_fields(...) expects field names as strings or one sequence of strings."
+            )
+        else:
+            selected = _normalize_field_names(field_names)  # type: ignore[arg-type]
         available = set(self.fields)
         missing = [field for field in selected if field not in available]
         if missing:
@@ -390,7 +397,25 @@ class Vector(AutoSerialize):
         until compaction. Calling ``compact()`` makes memory usage and save size
         predictable at the cost of reallocating the backing buffer.
         """
-        self._compact_storage()
+        data = self._state["data"]
+        used_rows = int(self._state["cell_lengths"].sum())
+        if used_rows == 0:
+            self._state["data"] = np.empty((0, self._full_num_fields), dtype=data.dtype)
+            self._state["cell_starts"].fill(0)
+            return
+
+        compacted = np.empty((used_rows, self._full_num_fields), dtype=data.dtype)
+        starts = np.zeros_like(self._state["cell_starts"])
+        cursor = 0
+        for linear_index in range(_cell_count(self._state["shape"])):
+            length = self._cell_row_count(linear_index)
+            starts[linear_index] = cursor
+            if length > 0:
+                cell = self._cell_matrix(linear_index)
+                compacted[cursor : cursor + length] = cell
+                cursor += length
+        self._state["data"] = compacted
+        self._state["cell_starts"] = starts
 
     def append_rows(self, idx: Any, rows: Any) -> None:
         """Append one or more rows to a single selected cell.
@@ -533,7 +558,9 @@ class Vector(AutoSerialize):
             _normalize_ufunc_input(value, total_rows, template.num_fields) for value in inputs
         ]
         result = ufunc(*flat_inputs, **kwargs)
-        return _wrap_ufunc_result(template, result, row_counts)
+        if isinstance(result, tuple):
+            return tuple(_vector_from_flat_result(template, item, row_counts) for item in result)
+        return _vector_from_flat_result(template, result, row_counts)
 
     def __add__(self, other: Any) -> "Vector":
         return self._binary_op(other, np.add)
@@ -642,14 +669,11 @@ class Vector(AutoSerialize):
             return np.arange(_cell_count(self._state["shape"]), dtype=np.int64)
         return self._selection_indices
 
-    def _is_full_field_selection(self) -> bool:
-        return self._selected_fields is None
-
     def _cell_row_count(self, linear_index: int) -> int:
         """Return the row count for one cell in the backing buffer."""
         return int(self._state["cell_lengths"][linear_index])
 
-    def _cell_matrix(self, linear_index: int) -> NDArray[np.generic]:
+    def _cell_matrix(self, linear_index: int) -> NDArray[Any]:
         """Return the full backing matrix for one cell."""
         start = int(self._state["cell_starts"][linear_index])
         length = int(self._state["cell_lengths"][linear_index])
@@ -657,7 +681,7 @@ class Vector(AutoSerialize):
             return self._state["data"][0:0]
         return self._state["data"][start : start + length]
 
-    def _selected_cell_matrix(self, linear_index: int) -> NDArray[np.generic]:
+    def _selected_cell_matrix(self, linear_index: int) -> NDArray[Any]:
         """Return one cell with the current field selection applied."""
         cell = self._cell_matrix(linear_index)
         cols = self._field_indices()
@@ -670,9 +694,7 @@ class Vector(AutoSerialize):
             return cell[:, int(cols[0]) : int(cols[-1]) + 1]
         return cell[:, cols].copy()
 
-    def _replace_cells(
-        self, targets: NDArray[np.int64], arrays: Sequence[NDArray[np.generic]]
-    ) -> None:
+    def _replace_cells(self, targets: NDArray[np.int64], arrays: Sequence[NDArray[Any]]) -> None:
         """Replace complete cells in the compact row buffer.
 
         Whole-cell replacement is implemented by appending the new payload rows to
@@ -707,12 +729,11 @@ class Vector(AutoSerialize):
     def _expand_storage(self, num_new_fields: int) -> None:
         """Append new ``np.nan``-initialized columns for added fields."""
         data = self._state["data"]
+        dtype = np.result_type(data.dtype, float)
         if data.shape[0] == 0:
-            dtype = np.result_type(data.dtype, float)
             self._state["data"] = np.empty((0, data.shape[1] + num_new_fields), dtype=dtype)
             return
 
-        dtype = np.result_type(data.dtype, float)
         filler = np.full((data.shape[0], num_new_fields), np.nan, dtype=dtype)
         self._state["data"] = np.concatenate((data.astype(dtype, copy=False), filler), axis=1)
 
@@ -724,33 +745,11 @@ class Vector(AutoSerialize):
             return
         if data.shape[0] <= 2 * used_rows:
             return
-        self._compact_storage()
-
-    def _compact_storage(self) -> None:
-        """Rebuild the row buffer so only live rows remain."""
-        data = self._state["data"]
-        used_rows = int(self._state["cell_lengths"].sum())
-        if used_rows == 0:
-            self._state["data"] = np.empty((0, self._full_num_fields), dtype=data.dtype)
-            self._state["cell_starts"].fill(0)
-            return
-
-        compacted = np.empty((used_rows, self._full_num_fields), dtype=data.dtype)
-        starts = np.zeros_like(self._state["cell_starts"])
-        cursor = 0
-        for linear_index in range(_cell_count(self._state["shape"])):
-            length = self._cell_row_count(linear_index)
-            starts[linear_index] = cursor
-            if length > 0:
-                cell = self._cell_matrix(linear_index)
-                compacted[cursor : cursor + length] = cell
-                cursor += length
-        self._state["data"] = compacted
-        self._state["cell_starts"] = starts
+        self.compact()
 
     def _assign(self, value: Any) -> None:
         """Dispatch assignment based on whether all fields or a subset are selected."""
-        if self._is_full_field_selection():
+        if self._selected_fields is None:
             self._assign_full_cells(value)
         else:
             self._assign_selected_fields(value)
@@ -878,6 +877,38 @@ class Vector(AutoSerialize):
             cursor += rows
 
 
+def _resolve_fields(
+    fields: Sequence[str] | None,
+    num_fields: int | None,
+    inferred: int | None,
+) -> list[str]:
+    """Resolve field names from constructor arguments.
+
+    ``inferred`` is the field count inferred from data; pass ``None`` when there
+    is no data source and explicit fields/num_fields are required.
+    """
+    if fields is not None:
+        root_fields = validate_fields(list(fields))
+        count = len(root_fields)
+        if num_fields is not None and count != num_fields:
+            raise ValueError(
+                f"num_fields ({num_fields}) does not match length of fields ({count})"
+            )
+        if inferred is not None and count != inferred:
+            raise ValueError(f"num_fields ({inferred}) does not match length of fields ({count})")
+        return root_fields
+    if num_fields is not None:
+        count = validate_num_fields(num_fields)
+        if inferred is not None and count != inferred:
+            raise ValueError(
+                f"Provided num_fields ({count}) does not match inferred ({inferred})."
+            )
+        return [f"field_{i}" for i in range(count)]
+    if inferred is not None:
+        return [f"field_{i}" for i in range(inferred)]
+    raise ValueError("Must specify either 'fields' or 'num_fields'.")
+
+
 def _cell_count(shape: tuple[int, ...]) -> int:
     """Return the number of fixed-grid cells in a shape."""
     return int(np.prod(shape, dtype=np.int64)) if shape else 1
@@ -893,24 +924,6 @@ def _normalize_field_names(field_names: str | Sequence[str]) -> tuple[str, ...]:
         raise ValueError("At least one field name is required.")
     validate_fields(list(normalized))
     return normalized
-
-
-def _normalize_select_field_args(*field_names: str | Sequence[str]) -> tuple[str, ...]:
-    """Normalize ``select_fields`` arguments.
-
-    This accepts either ``select_fields("a", "b")`` or
-    ``select_fields(["a", "b"])`` while keeping ``add_fields`` /
-    ``remove_fields`` on the simpler single-argument path.
-    """
-    if not field_names:
-        raise ValueError("At least one field name is required.")
-    if len(field_names) == 1 and not isinstance(field_names[0], str):
-        return _normalize_field_names(field_names[0])
-    if not all(isinstance(name, str) for name in field_names):
-        raise TypeError(
-            "select_fields(...) expects field names as strings or one sequence of strings."
-        )
-    return _normalize_field_names(cast(Sequence[str], field_names))
 
 
 def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]:
@@ -933,12 +946,12 @@ def _looks_like_field_selector(idx: Any) -> bool:
         return True
     if isinstance(idx, tuple) and any(_looks_like_field_selector(item) for item in idx):
         return True
-    if isinstance(idx, (list, tuple)) and idx and all(isinstance(item, str) for item in idx):
+    if isinstance(idx, list) and idx and all(isinstance(item, str) for item in idx):
         return True
     return False
 
 
-def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
+def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[Any]:
     """Normalize a single-cell payload to shape ``(n_rows, num_fields)``."""
     if isinstance(value, Vector):
         if value.shape != ():
@@ -963,16 +976,7 @@ def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
     return array
 
 
-def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
-    """Normalize nested input data into ``(shape, flat_cell_arrays)``."""
-    if not isinstance(data, list):
-        raise TypeError("Data must be a list")
-    if not data:
-        return (0,), []
-    return _flatten_fixed_grid(data)
-
-
-def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
+def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[Any]]]:
     """Recursively flatten nested fixed-grid input into row-major cell order."""
     if isinstance(node, np.ndarray):
         return (), [_coerce_inferred_cell_array(node)]
@@ -984,7 +988,7 @@ def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.gen
         return (0,), []
 
     child_shape: tuple[int, ...] | None = None
-    cells: list[NDArray[np.generic]] = []
+    cells: list[NDArray[Any]] = []
     for child in node:
         shape, child_cells = _flatten_fixed_grid(child)
         if child_shape is None:
@@ -1013,7 +1017,7 @@ def _is_row_like(item: Any) -> bool:
     return all(np.isscalar(value) for value in item)
 
 
-def _coerce_inferred_cell_array(value: Any) -> NDArray[np.generic]:
+def _coerce_inferred_cell_array(value: Any) -> NDArray[Any]:
     """Infer a 2D cell array from row-like input during ``from_data``."""
     array = np.asarray(value)
     if array.ndim == 0:
@@ -1138,7 +1142,7 @@ def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], 
     return positions, False
 
 
-def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDArray[np.generic]:
+def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDArray[Any]:
     """Broadcast array-like input to flattened rowwise assignment shape."""
     array = np.asarray(value)
     if array.ndim == 0:
@@ -1166,17 +1170,6 @@ def _normalize_ufunc_input(value: Any, total_rows: int, num_fields: int) -> Any:
     return _broadcast_field_values(value, total_rows, num_fields)
 
 
-def _wrap_ufunc_result(
-    template: Vector,
-    result: Any,
-    row_counts: list[int],
-) -> Any:
-    """Convert elementwise ufunc output back into Vector selections."""
-    if isinstance(result, tuple):
-        return tuple(_vector_from_flat_result(template, item, row_counts) for item in result)
-    return _vector_from_flat_result(template, result, row_counts)
-
-
 def _vector_from_flat_result(
     template: Vector,
     values: Any,
@@ -1199,7 +1192,7 @@ def _vector_from_flat_result(
         return result
 
     cursor = 0
-    cells: list[NDArray[np.generic]] = []
+    cells: list[NDArray[Any]] = []
     for rows in row_counts:
         cells.append(flat_values[cursor : cursor + rows].copy())
         cursor += rows

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -93,6 +93,10 @@ class Vector(AutoSerialize):
     __array_priority__ = 1000
     _token = object()
 
+    # ------------------------------------------------------------------ #
+    # Construction
+    # ------------------------------------------------------------------ #
+
     def __init__(
         self,
         shape: tuple[int, ...],
@@ -200,6 +204,28 @@ class Vector(AutoSerialize):
         vector._replace_cells(np.arange(len(cell_arrays), dtype=np.int64), cell_arrays)
         return vector
 
+    # ------------------------------------------------------------------ #
+    # Identity properties
+    # ------------------------------------------------------------------ #
+
+    @property
+    def name(self) -> str:
+        """Human-readable Vector name."""
+        return self._state["name"]
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self._state["name"] = str(value)
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Mutable metadata dictionary shared by all views."""
+        return self._state["metadata"]
+
+    # ------------------------------------------------------------------ #
+    # Shape & structure properties
+    # ------------------------------------------------------------------ #
+
     @property
     def shape(self) -> tuple[int, ...]:
         """Return the fixed-grid shape of this selection."""
@@ -224,23 +250,23 @@ class Vector(AutoSerialize):
         return len(self.fields)
 
     @property
+    def num_cells(self) -> int:
+        """Return the number of fixed-grid cells in the current selection."""
+        return int(self._selected_cell_indices().size)
+
+    @property
+    def total_rows(self) -> int:
+        """Return the total ragged-row count in the current selection."""
+        return int(self._state["cell_lengths"][self._selected_cell_indices()].sum())
+
+    @property
     def dtype(self) -> np.dtype[Any]:
         """Return the NumPy dtype of the backing row buffer."""
         return self._state["data"].dtype
 
-    @property
-    def name(self) -> str:
-        """Human-readable Vector name."""
-        return self._state["name"]
-
-    @name.setter
-    def name(self, value: str) -> None:
-        self._state["name"] = str(value)
-
-    @property
-    def metadata(self) -> dict[str, Any]:
-        """Mutable metadata dictionary shared by all views."""
-        return self._state["metadata"]
+    # ------------------------------------------------------------------ #
+    # Data access
+    # ------------------------------------------------------------------ #
 
     @property
     def array(self) -> NDArray[Any]:
@@ -264,40 +290,6 @@ class Vector(AutoSerialize):
             return cell[:, int(cols[0]) : int(cols[-1]) + 1]
         return cell[:, cols].copy()
 
-    def __len__(self) -> int:
-        """Return ``shape[0]`` for non-scalar selections."""
-        if self.shape == ():
-            raise TypeError("len() of unsized 0D Vector")
-        return self.shape[0]
-
-    def __repr__(self) -> str:
-        return "\n".join(
-            [
-                f"quantem.Vector, shape={self.shape}, name={self.name}",
-                f"  fields = {self.fields}",
-                f"  units: {self.units}",
-            ]
-        )
-
-    __str__ = __repr__
-
-    def copy(self) -> "Vector":
-        """Return a deep copy of the current selection."""
-        copied = self.__class__(
-            shape=self.shape,
-            fields=self.fields,
-            units=self.units,
-            name=self.name,
-            metadata=copy.deepcopy(self.metadata),
-            _token=self.__class__._token,
-        )
-        target_cells = copied._selected_cell_indices()
-        source_arrays = [
-            self._selected_cell_matrix(index).copy() for index in self._selected_cell_indices()
-        ]
-        copied._replace_cells(target_cells, source_arrays)
-        return copied
-
     def flatten(self) -> NDArray[Any]:
         """Concatenate selected cells in row-major order.
 
@@ -315,19 +307,13 @@ class Vector(AutoSerialize):
         dtype = self._state["data"].dtype if self._state["data"].ndim == 2 else float
         return np.empty((0, self.num_fields), dtype=dtype)
 
-    @property
-    def total_rows(self) -> int:
-        """Return the total ragged-row count in the current selection."""
-        return int(self._state["cell_lengths"][self._selected_cell_indices()].sum())
-
-    @property
-    def num_cells(self) -> int:
-        """Return the number of fixed-grid cells in the current selection."""
-        return int(self._selected_cell_indices().size)
-
     def row_counts(self) -> list[int]:
         """Return per-cell row counts in the current selection order."""
         return [self._cell_row_count(int(index)) for index in self._selected_cell_indices()]
+
+    # ------------------------------------------------------------------ #
+    # Field management
+    # ------------------------------------------------------------------ #
 
     def select_fields(self, *field_names: str | Sequence[str]) -> "Vector":
         """Return a view containing only the requested fields.
@@ -362,82 +348,6 @@ class Vector(AutoSerialize):
             self._selection_indices,
             selected_fields,
         )
-
-    def set_flattened(self, values: Any) -> None:
-        """Write values back in flattened row-major order.
-
-        This updates existing rows without changing per-cell row counts. It is
-        the rowwise companion to ``flatten()`` and is especially useful for
-        NumPy-based transforms that operate on all selected rows at once.
-        """
-        field_indices = self._field_indices()
-        targets = self._selected_cell_indices()
-        row_counts = self.row_counts()
-        total_rows = sum(row_counts)
-
-        if isinstance(values, Vector):
-            if values.num_fields != self.num_fields:
-                raise ValueError(f"Expected {self.num_fields} fields, got {values.num_fields}")
-            flat_values = values.flatten()
-            if flat_values.shape[0] != total_rows:
-                raise ValueError(f"Expected {total_rows} rows, got {flat_values.shape[0]}")
-        else:
-            flat_values = _broadcast_field_values(values, total_rows, self.num_fields)
-
-        cursor = 0
-        for target, rows in zip(targets, row_counts):
-            cell = self._cell_matrix(int(target))
-            if rows > 0:
-                cell[:, field_indices] = flat_values[cursor : cursor + rows]
-            cursor += rows
-
-    def compact(self) -> None:
-        """Repack the backing row buffer to remove dead rows.
-
-        Whole-cell replacement appends new rows and leaves previous rows unused
-        until compaction. Calling ``compact()`` makes memory usage and save size
-        predictable at the cost of reallocating the backing buffer.
-        """
-        data = self._state["data"]
-        used_rows = int(self._state["cell_lengths"].sum())
-        if used_rows == 0:
-            self._state["data"] = np.empty((0, self._full_num_fields), dtype=data.dtype)
-            self._state["cell_starts"].fill(0)
-            return
-
-        compacted = np.empty((used_rows, self._full_num_fields), dtype=data.dtype)
-        starts = np.zeros_like(self._state["cell_starts"])
-        cursor = 0
-        for linear_index in range(_cell_count(self._state["shape"])):
-            length = self._cell_row_count(linear_index)
-            starts[linear_index] = cursor
-            if length > 0:
-                cell = self._cell_matrix(linear_index)
-                compacted[cursor : cursor + length] = cell
-                cursor += length
-        self._state["data"] = compacted
-        self._state["cell_starts"] = starts
-
-    def append_rows(self, idx: Any, rows: Any) -> None:
-        """Append one or more rows to a single selected cell.
-
-        ``idx`` is interpreted with the same fixed-grid indexing rules as
-        ``__getitem__`` and must resolve to exactly one cell. Appending rows is a
-        full-cell operation, so all fields must be selected.
-        """
-        target = self[idx]
-        if target.shape != ():
-            raise ValueError("append_rows requires an index that selects exactly one cell.")
-        target._require_full_field_view("append_rows")
-
-        new_rows = _coerce_cell_array(rows, target.num_fields)
-        if new_rows.shape[0] == 0:
-            return
-
-        cell_index = int(target._selected_cell_indices()[0])
-        existing = target._cell_matrix(cell_index)
-        combined = np.vstack((existing, new_rows)) if existing.shape[0] > 0 else new_rows.copy()
-        target._replace_cells(np.array([cell_index], dtype=np.int64), [combined])
 
     def add_fields(
         self,
@@ -523,6 +433,124 @@ class Vector(AutoSerialize):
             if len(self._selected_fields) == len(self._state["fields"]):
                 self._selected_fields = None
 
+    # ------------------------------------------------------------------ #
+    # Cell / row mutation
+    # ------------------------------------------------------------------ #
+
+    def append_rows(self, idx: Any, rows: Any) -> None:
+        """Append one or more rows to a single selected cell.
+
+        ``idx`` is interpreted with the same fixed-grid indexing rules as
+        ``__getitem__`` and must resolve to exactly one cell. Appending rows is a
+        full-cell operation, so all fields must be selected.
+        """
+        target = self[idx]
+        if target.shape != ():
+            raise ValueError("append_rows requires an index that selects exactly one cell.")
+        target._require_full_field_view("append_rows")
+
+        new_rows = _coerce_cell_array(rows, target.num_fields)
+        if new_rows.shape[0] == 0:
+            return
+
+        cell_index = int(target._selected_cell_indices()[0])
+        existing = target._cell_matrix(cell_index)
+        combined = np.vstack((existing, new_rows)) if existing.shape[0] > 0 else new_rows.copy()
+        target._replace_cells(np.array([cell_index], dtype=np.int64), [combined])
+
+    def set_flattened(self, values: Any) -> None:
+        """Write values back in flattened row-major order.
+
+        This updates existing rows without changing per-cell row counts. It is
+        the rowwise companion to ``flatten()`` and is especially useful for
+        NumPy-based transforms that operate on all selected rows at once.
+        """
+        field_indices = self._field_indices()
+        targets = self._selected_cell_indices()
+        row_counts = self.row_counts()
+        total_rows = sum(row_counts)
+
+        if isinstance(values, Vector):
+            if values.num_fields != self.num_fields:
+                raise ValueError(f"Expected {self.num_fields} fields, got {values.num_fields}")
+            flat_values = values.flatten()
+            if flat_values.shape[0] != total_rows:
+                raise ValueError(f"Expected {total_rows} rows, got {flat_values.shape[0]}")
+        else:
+            flat_values = _broadcast_field_values(values, total_rows, self.num_fields)
+
+        cursor = 0
+        for target, rows in zip(targets, row_counts):
+            cell = self._cell_matrix(int(target))
+            if rows > 0:
+                cell[:, field_indices] = flat_values[cursor : cursor + rows]
+            cursor += rows
+
+    def compact(self) -> None:
+        """Repack the backing row buffer to remove dead rows.
+
+        Whole-cell replacement appends new rows and leaves previous rows unused
+        until compaction. Calling ``compact()`` makes memory usage and save size
+        predictable at the cost of reallocating the backing buffer.
+        """
+        data = self._state["data"]
+        used_rows = int(self._state["cell_lengths"].sum())
+        if used_rows == 0:
+            self._state["data"] = np.empty((0, self._full_num_fields), dtype=data.dtype)
+            self._state["cell_starts"].fill(0)
+            return
+
+        compacted = np.empty((used_rows, self._full_num_fields), dtype=data.dtype)
+        starts = np.zeros_like(self._state["cell_starts"])
+        cursor = 0
+        for linear_index in range(_cell_count(self._state["shape"])):
+            length = self._cell_row_count(linear_index)
+            starts[linear_index] = cursor
+            if length > 0:
+                cell = self._cell_matrix(linear_index)
+                compacted[cursor : cursor + length] = cell
+                cursor += length
+        self._state["data"] = compacted
+        self._state["cell_starts"] = starts
+
+    # ------------------------------------------------------------------ #
+    # Python data model
+    # ------------------------------------------------------------------ #
+
+    def __len__(self) -> int:
+        """Return ``shape[0]`` for non-scalar selections."""
+        if self.shape == ():
+            raise TypeError("len() of unsized 0D Vector")
+        return self.shape[0]
+
+    def __repr__(self) -> str:
+        return "\n".join(
+            [
+                f"quantem.Vector, shape={self.shape}, name={self.name}",
+                f"  fields = {self.fields}",
+                f"  units: {self.units}",
+            ]
+        )
+
+    __str__ = __repr__
+
+    def copy(self) -> "Vector":
+        """Return a deep copy of the current selection."""
+        copied = self.__class__(
+            shape=self.shape,
+            fields=self.fields,
+            units=self.units,
+            name=self.name,
+            metadata=copy.deepcopy(self.metadata),
+            _token=self.__class__._token,
+        )
+        target_cells = copied._selected_cell_indices()
+        source_arrays = [
+            self._selected_cell_matrix(index).copy() for index in self._selected_cell_indices()
+        ]
+        copied._replace_cells(target_cells, source_arrays)
+        return copied
+
     def __getitem__(self, idx: Any) -> "Vector":
         """Return a fixed-grid selection as another Vector view."""
         if _looks_like_field_selector(idx):
@@ -549,6 +577,10 @@ class Vector(AutoSerialize):
         else:
             target = self[idx]
         target._assign(value)
+
+    # ------------------------------------------------------------------ #
+    # Arithmetic operators
+    # ------------------------------------------------------------------ #
 
     def __array_ufunc__(self, ufunc: Any, method: str, *inputs: Any, **kwargs: Any) -> Any:
         """Apply supported NumPy ufuncs elementwise.
@@ -668,6 +700,54 @@ class Vector(AutoSerialize):
         result._inplace_unary(np.abs)
         return result
 
+    # ------------------------------------------------------------------ #
+    # I/O
+    # ------------------------------------------------------------------ #
+
+    def save(
+        self,
+        path: str | Path,
+        mode: Literal["w", "o"] = "w",
+        store: Literal["auto", "zip", "dir"] = "auto",
+        skip: str | type | Sequence[str | type] = (),
+        compression_level: int | None = 4,
+    ) -> None:
+        """
+        Save the Vector object to disk using Zarr serialization. self.compact() is called before
+        saving to reduce file size if possible.
+
+        Parameters
+        ----------
+        path : str or Path
+            Target file path. Use '.zip' extension for zip format, otherwise a directory.
+        mode : {'w', 'o'}
+            'w' = write only if file doesn't exist, 'o' = overwrite if it does.
+        store : {'auto', 'zip', 'dir'}
+            Storage format. 'auto' infers from file extension.
+        skip : str, type, or list of (str or type)
+            Attribute names/types to skip (by name or type) during serialization.
+        compression_level : int or None
+            If set (0–9), applies Zstandard compression with Blosc backend at that level.
+            Level 0 disables compression. Raises ValueError if > 9.
+
+        Notes
+        -----
+        Skipped attribute names and types are also stored in the file metadata for correct
+        round-trip skipping during load().
+        """
+        self.compact()
+        super().save(
+            path,
+            mode=mode,
+            store=store,
+            skip=skip,
+            compression_level=compression_level,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Private helpers — backing-store access
+    # ------------------------------------------------------------------ #
+
     @property
     def _full_num_fields(self) -> int:
         return len(self._state["fields"])
@@ -772,6 +852,10 @@ class Vector(AutoSerialize):
             return
         self.compact()
 
+    # ------------------------------------------------------------------ #
+    # Private helpers — assignment
+    # ------------------------------------------------------------------ #
+
     def _assign(self, value: Any) -> None:
         """Dispatch assignment based on whether all fields or a subset are selected."""
         if self._selected_fields is None:
@@ -844,6 +928,10 @@ class Vector(AutoSerialize):
                 cell[:, field_indices] = chunk
             cursor += rows
 
+    # ------------------------------------------------------------------ #
+    # Private helpers — arithmetic
+    # ------------------------------------------------------------------ #
+
     def _binary_op(self, other: Any, op: Any, reverse: bool = False) -> "Vector":
         """Return a new Vector produced by elementwise arithmetic."""
         result = self.copy()
@@ -900,46 +988,6 @@ class Vector(AutoSerialize):
             if rows > 0:
                 cell[:, field_indices] = op(chunk, lhs) if reverse else op(lhs, chunk)
             cursor += rows
-
-    def save(
-        self,
-        path: str | Path,
-        mode: Literal["w", "o"] = "w",
-        store: Literal["auto", "zip", "dir"] = "auto",
-        skip: str | type | Sequence[str | type] = (),
-        compression_level: int | None = 4,
-    ) -> None:
-        """
-        Save the Vector object to disk using Zarr serialization. self.compact() is called before
-        saving to reduce file size if possible.
-
-        Parameters
-        ----------
-        path : str or Path
-            Target file path. Use '.zip' extension for zip format, otherwise a directory.
-        mode : {'w', 'o'}
-            'w' = write only if file doesn't exist, 'o' = overwrite if it does.
-        store : {'auto', 'zip', 'dir'}
-            Storage format. 'auto' infers from file extension.
-        skip : str, type, or list of (str or type)
-            Attribute names/types to skip (by name or type) during serialization.
-        compression_level : int or None
-            If set (0–9), applies Zstandard compression with Blosc backend at that level.
-            Level 0 disables compression. Raises ValueError if > 9.
-
-        Notes
-        -----
-        Skipped attribute names and types are also stored in the file metadata for correct
-        round-trip skipping during load().
-        """
-        self.compact()
-        super().save(
-            path,
-            mode=mode,
-            store=store,
-            skip=skip,
-            compression_level=compression_level,
-        )
 
 
 def _resolve_fields(

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import Any, Sequence, overload
+from typing import Any, Sequence, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -132,7 +132,9 @@ class Vector(AutoSerialize):
         obj = cls.__new__(cls)
         obj._state = state
         obj._selection_shape = selection_shape
-        obj._selection_indices = None if selection_indices is None else selection_indices.astype(np.int64, copy=False)
+        obj._selection_indices = (
+            None if selection_indices is None else selection_indices.astype(np.int64, copy=False)
+        )
         obj._selected_fields = selected_fields
         return obj
 
@@ -215,10 +217,7 @@ class Vector(AutoSerialize):
     @property
     def units(self) -> list[str]:
         """Return units for the selected fields."""
-        lookup = {
-            field: unit
-            for field, unit in zip(self._state["fields"], self._state["units"])
-        }
+        lookup = {field: unit for field, unit in zip(self._state["fields"], self._state["units"])}
         return [lookup[field] for field in self.fields]
 
     @property
@@ -294,7 +293,9 @@ class Vector(AutoSerialize):
             metadata=copy.deepcopy(self.metadata),
         )
         target_cells = copied._selected_cell_indices()
-        source_arrays = [self._selected_cell_matrix(index).copy() for index in self._selected_cell_indices()]
+        source_arrays = [
+            self._selected_cell_matrix(index).copy() for index in self._selected_cell_indices()
+        ]
         copied._replace_cells(target_cells, source_arrays)
         return copied
 
@@ -434,7 +435,11 @@ class Vector(AutoSerialize):
             return
 
         target = self.select_fields(*new_fields)
-        if len(new_fields) > 1 and isinstance(values, (list, tuple)) and len(values) == len(new_fields):
+        if (
+            len(new_fields) > 1
+            and isinstance(values, (list, tuple))
+            and len(values) == len(new_fields)
+        ):
             for field, value in zip(new_fields, values):
                 target.select_fields(field)[...] = value
         else:
@@ -462,12 +467,11 @@ class Vector(AutoSerialize):
         self._state["data"] = self._state["data"][:, keep]
 
         if self._selected_fields is not None:
-            self._selected_fields = tuple(field for field in self._selected_fields if field in self._state["fields"])
+            self._selected_fields = tuple(
+                field for field in self._selected_fields if field in self._state["fields"]
+            )
             if len(self._selected_fields) == len(self._state["fields"]):
                 self._selected_fields = None
-
-    @overload
-    def __getitem__(self, idx: Any) -> "Vector": ...
 
     def __getitem__(self, idx: Any) -> "Vector":
         """Return a fixed-grid selection as another Vector view."""
@@ -525,7 +529,9 @@ class Vector(AutoSerialize):
             if other.row_counts() != row_counts:
                 raise ValueError("Vector ufunc inputs must have matching per-cell row counts.")
 
-        flat_inputs = [_normalize_ufunc_input(value, total_rows, template.num_fields) for value in inputs]
+        flat_inputs = [
+            _normalize_ufunc_input(value, total_rows, template.num_fields) for value in inputs
+        ]
         result = ufunc(*flat_inputs, **kwargs)
         return _wrap_ufunc_result(template, result, row_counts)
 
@@ -664,7 +670,9 @@ class Vector(AutoSerialize):
             return cell[:, int(cols[0]) : int(cols[-1]) + 1]
         return cell[:, cols].copy()
 
-    def _replace_cells(self, targets: NDArray[np.int64], arrays: Sequence[NDArray[np.generic]]) -> None:
+    def _replace_cells(
+        self, targets: NDArray[np.int64], arrays: Sequence[NDArray[np.generic]]
+    ) -> None:
         """Replace complete cells in the compact row buffer.
 
         Whole-cell replacement is implemented by appending the new payload rows to
@@ -759,9 +767,7 @@ class Vector(AutoSerialize):
             if len(targets) != len(source_cells):
                 raise ValueError(f"Expected {len(targets)} cells, got {len(source_cells)}")
             if value.num_fields != self.num_fields:
-                raise ValueError(
-                    f"Expected {self.num_fields} fields, got {value.num_fields}"
-                )
+                raise ValueError(f"Expected {self.num_fields} fields, got {value.num_fields}")
             arrays = [value._selected_cell_matrix(index).copy() for index in source_cells]
             self._replace_cells(targets, arrays)
             return
@@ -787,9 +793,7 @@ class Vector(AutoSerialize):
             if len(targets) != len(source_cells):
                 raise ValueError(f"Expected {len(targets)} cells, got {len(source_cells)}")
             if value.num_fields != self.num_fields:
-                raise ValueError(
-                    f"Expected {self.num_fields} fields, got {value.num_fields}"
-                )
+                raise ValueError(f"Expected {self.num_fields} fields, got {value.num_fields}")
             source_counts = [value._cell_row_count(index) for index in source_cells]
             if row_counts != source_counts:
                 raise ValueError("Per-cell row counts must match for field-selected assignment.")
@@ -903,9 +907,10 @@ def _normalize_select_field_args(*field_names: str | Sequence[str]) -> tuple[str
     if len(field_names) == 1 and not isinstance(field_names[0], str):
         return _normalize_field_names(field_names[0])
     if not all(isinstance(name, str) for name in field_names):
-        raise TypeError("select_fields(...) expects field names as strings or one sequence of strings.")
-    return _normalize_field_names(field_names)
-
+        raise TypeError(
+            "select_fields(...) expects field names as strings or one sequence of strings."
+        )
+    return _normalize_field_names(cast(Sequence[str], field_names))
 
 
 def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]:
@@ -922,7 +927,6 @@ def _normalize_units(units: str | Sequence[str] | None, count: int) -> list[str]
     return normalized
 
 
-
 def _looks_like_field_selector(idx: Any) -> bool:
     """Return True for indices that look like field selection by mistake."""
     if isinstance(idx, str):
@@ -932,7 +936,6 @@ def _looks_like_field_selector(idx: Any) -> bool:
     if isinstance(idx, (list, tuple)) and idx and all(isinstance(item, str) for item in idx):
         return True
     return False
-
 
 
 def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
@@ -960,7 +963,6 @@ def _coerce_cell_array(value: Any, num_fields: int) -> NDArray[np.generic]:
     return array
 
 
-
 def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
     """Normalize nested input data into ``(shape, flat_cell_arrays)``."""
     if not isinstance(data, list):
@@ -968,7 +970,6 @@ def _normalize_nested_data(data: list[Any]) -> tuple[tuple[int, ...], list[NDArr
     if not data:
         return (0,), []
     return _flatten_fixed_grid(data)
-
 
 
 def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.generic]]]:
@@ -996,13 +997,11 @@ def _flatten_fixed_grid(node: Any) -> tuple[tuple[int, ...], list[NDArray[np.gen
     return (len(node),) + child_shape, cells
 
 
-
 def _looks_like_cell_rows(node: Sequence[Any]) -> bool:
     """Return True when a sequence should be interpreted as cell rows, not grid nesting."""
     if len(node) == 0:
         return True
     return all(_is_row_like(item) for item in node)
-
 
 
 def _is_row_like(item: Any) -> bool:
@@ -1012,7 +1011,6 @@ def _is_row_like(item: Any) -> bool:
     if not isinstance(item, (list, tuple)):
         return False
     return all(np.isscalar(value) for value in item)
-
 
 
 def _coerce_inferred_cell_array(value: Any) -> NDArray[np.generic]:
@@ -1027,7 +1025,6 @@ def _coerce_inferred_cell_array(value: Any) -> NDArray[np.generic]:
     if array.ndim != 2:
         raise ValueError("Cell data must be 1D or 2D.")
     return array
-
 
 
 def _select_linear_indices(
@@ -1066,11 +1063,13 @@ def _select_linear_indices(
         value = int(current_grid[scalar_key])
         return (), np.array([value], dtype=np.int64)
 
-    mesh_inputs = [positions if not is_scalar else positions[:1] for positions, is_scalar in zip(axis_positions, scalar_axes)]
+    mesh_inputs = [
+        positions if not is_scalar else positions[:1]
+        for positions, is_scalar in zip(axis_positions, scalar_axes)
+    ]
     grids = np.meshgrid(*mesh_inputs, indexing="ij")
     selected = np.asarray(current_grid[tuple(grids)], dtype=np.int64).reshape(-1)
     return tuple(out_shape), selected
-
 
 
 def _normalize_index_tuple(idx: Any, ndim: int) -> tuple[Any, ...]:
@@ -1092,7 +1091,6 @@ def _normalize_index_tuple(idx: Any, ndim: int) -> tuple[Any, ...]:
     if len(idx) < ndim:
         idx = idx + (slice(None),) * (ndim - len(idx))
     return idx
-
 
 
 def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], bool]:
@@ -1121,7 +1119,9 @@ def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], 
         if array.ndim != 1:
             raise IndexError("Full-grid boolean masks are not supported.")
         if array.shape[0] != size:
-            raise IndexError(f"Boolean mask length {array.shape[0]} does not match axis length {size}")
+            raise IndexError(
+                f"Boolean mask length {array.shape[0]} does not match axis length {size}"
+            )
         return np.flatnonzero(array).astype(np.int64, copy=False), False
 
     if array.ndim != 1:
@@ -1136,7 +1136,6 @@ def _positions_for_axis(axis_index: Any, size: int) -> tuple[NDArray[np.int64], 
     if np.any((positions < 0) | (positions >= size)):
         raise IndexError("Vector index out of range")
     return positions, False
-
 
 
 def _broadcast_field_values(value: Any, total_rows: int, num_fields: int) -> NDArray[np.generic]:
@@ -1207,7 +1206,6 @@ def _vector_from_flat_result(
 
     result._replace_cells(result._selected_cell_indices(), cells)
     return result
-
 
 
 def _is_contiguous(indices: NDArray[np.int64]) -> bool:

--- a/src/quantem/core/datastructures/vector.py
+++ b/src/quantem/core/datastructures/vector.py
@@ -225,6 +225,11 @@ class Vector(AutoSerialize):
         return len(self.fields)
 
     @property
+    def dtype(self) -> np.dtype[Any]:
+        """Return the NumPy dtype of the backing row buffer."""
+        return self._state["data"].dtype
+
+    @property
     def name(self) -> str:
         """Human-readable Vector name."""
         return self._state["name"]
@@ -312,6 +317,11 @@ class Vector(AutoSerialize):
     def total_rows(self) -> int:
         """Return the total ragged-row count in the current selection."""
         return int(self._state["cell_lengths"][self._selected_cell_indices()].sum())
+
+    @property
+    def num_cells(self) -> int:
+        """Return the number of fixed-grid cells in the current selection."""
+        return int(self._selected_cell_indices().size)
 
     def row_counts(self) -> list[int]:
         """Return per-cell row counts in the current selection order."""

--- a/src/quantem/core/visualization/visualization_utils.py
+++ b/src/quantem/core/visualization/visualization_utils.py
@@ -503,6 +503,14 @@ def bilinear_histogram_2d(
     x0, y0 = origin
     x1, y1 = x0 + Nx * dx, y0 + Ny * dy
 
+    x = _as_histogram_vector(x, "x")
+    y = _as_histogram_vector(y, "y")
+    weight = _as_histogram_vector(weight, "weight")
+    if not (x.shape == y.shape == weight.shape):
+        raise ValueError(
+            f"x, y, and weight must have matching shapes after coercion, got {x.shape}, {y.shape}, {weight.shape}"
+        )
+
     # Convert shape tuple to list for binned_statistic_2d
     bins: Sequence[int] = [Nx, Ny]
     hist, _, _, _ = binned_statistic_2d(
@@ -515,6 +523,15 @@ def bilinear_histogram_2d(
     )
 
     return hist  # shape = (Nx, Ny), i.e., array[x, y]
+
+
+def _as_histogram_vector(value: NDArray, name: str) -> NDArray:
+    array = np.asarray(value)
+    if array.ndim == 1:
+        return array
+    if array.ndim == 2 and 1 in array.shape:
+        return array.reshape(-1)
+    raise ValueError(f"{name} must be 1D or shape (N, 1)/(1, N), got {array.shape}")
 
 
 def axes_with_inset(

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -339,6 +339,27 @@ class TestVector:
         with pytest.raises(ValueError, match="all fields are selected"):
             v2.select_fields("kx").add_fields("bad")
 
+    def test_rename_fields(self):
+        v = make_line_vector()
+        kx_data = v.select_fields("kx").flatten().copy()
+
+        v.rename_fields({"kx": "qx", "ky": "qy"})
+        assert v.fields == ["intensity", "qx", "qy"]
+        np.testing.assert_array_equal(v.select_fields("qx").flatten(), kx_data)
+
+        # Renaming through a field-selected view updates that view's selected names
+        view = v.select_fields("qx")
+        assert view.fields == ["qx"]
+        view.rename_fields({"qx": "px"})
+        assert view.fields == ["px"]
+        assert v.fields == ["intensity", "px", "qy"]
+
+        with pytest.raises(KeyError, match="Unknown field"):
+            v.rename_fields({"nonexistent": "x"})
+
+        with pytest.raises(ValueError, match="already exist"):
+            v.rename_fields({"px": "intensity"})
+
     def test_remove_fields_preserves_remaining_data(self):
         v = make_line_vector()
         v.add_fields("extra", 1.0)

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -4,430 +4,231 @@ import pytest
 from quantem.core.datastructures.vector import Vector
 
 
-class TestVector:
-    """Test suite for the Vector class."""
 
-    def test_initialization(self):
-        """Test Vector initialization with different parameters."""
-        # Test with fields
-        v1 = Vector.from_shape(shape=(2, 3), fields=["field0", "field1", "field2"])
+def make_line_vector() -> Vector:
+    v = Vector.from_shape(
+        shape=(4,),
+        fields=["intensity", "kx", "ky"],
+        units=["a.u.", "px", "px"],
+        name="line",
+    )
+    v[0] = np.array([[1.0, 10.0, 100.0], [2.0, 20.0, 200.0]])
+    v[1] = np.array([[3.0, 30.0, 300.0]])
+    v[2] = np.array([[4.0, 40.0, 400.0], [5.0, 50.0, 500.0]])
+    v[3] = np.array([[6.0, 60.0, 600.0]])
+    return v
+
+
+
+def make_grid_vector() -> Vector:
+    v = Vector.from_shape(shape=(3, 2), fields=["intensity", "kx", "ky"])
+    for i in range(3):
+        for j in range(2):
+            base = float(i * 10 + j)
+            v[i, j] = np.array([[base, base + 100.0, base + 200.0]])
+    return v
+
+
+class TestVector:
+    def test_initialization_and_len(self):
+        v1 = Vector.from_shape(shape=(2, 3), fields=["a", "b", "c"])
         assert v1.shape == (2, 3)
+        assert len(v1) == 2
         assert v1.num_fields == 3
-        assert v1.fields == ["field0", "field1", "field2"]
+        assert v1.fields == ["a", "b", "c"]
         assert v1.units == ["none", "none", "none"]
         assert v1.name == "2d ragged array"
-        assert hasattr(v1, "metadata")
+        assert v1[0, 0].array.shape == (0, 3)
+        np.testing.assert_array_equal(v1[0, 0].flatten(), v1[0, 0].array)
 
-        # Test with num_fields
-        v2 = Vector.from_shape(shape=(2, 3), num_fields=3)
-        assert v2.shape == (2, 3)
-        assert v2.num_fields == 3
-        assert v2.fields == ["field_0", "field_1", "field_2"]
-        assert v2.units == ["none", "none", "none"]
-        assert hasattr(v2, "metadata")
+        v2 = Vector.from_shape(shape=(2, 3), num_fields=2)
+        assert v2.fields == ["field_0", "field_1"]
 
-        # Test with custom name and units
-        v3 = Vector.from_shape(
-            shape=(2, 3),
-            fields=["field0", "field1", "field2"],
-            name="my_vector",
-            units=["unit0", "unit1", "unit2"],
-        )
-        assert v3.name == "my_vector"
-        assert v3.units == ["unit0", "unit1", "unit2"]
-        assert hasattr(v3, "metadata")
+        with pytest.raises(TypeError):
+            len(v1[0, 0])
 
-        # Test error cases
         with pytest.raises(ValueError, match="Must specify either 'fields' or 'num_fields'."):
             Vector.from_shape(shape=(2, 3))
 
         with pytest.raises(ValueError, match="does not match length of fields"):
-            Vector.from_shape(shape=(2, 3), num_fields=3, fields=["field0", "field1"])
+            Vector.from_shape(shape=(2, 3), num_fields=2, fields=["a", "b", "c"])
 
         with pytest.raises(ValueError, match="Duplicate field names"):
-            Vector.from_shape(shape=(2, 3), fields=["field0", "field0", "field2"])
+            Vector.from_shape(shape=(2, 3), fields=["a", "a"])
 
-    def test_data_access(self):
-        """Test data access and assignment."""
-        v = Vector.from_shape(shape=(2, 3), fields=["field0", "field1", "field2"])
+    def test_indexing_and_array_contract(self):
+        v = make_grid_vector()
 
-        # Set data at specific indices
-        data1 = np.array([[1.0, 2.0, 3.0]])
-        v[0, 0] = data1
-        np.testing.assert_array_equal(v.get_data(0, 0), data1)  # type: ignore
-
-        # Test get_data method
-        assert np.array_equal(v.get_data(0, 0), data1)
-
-        # Test set_data method
-        data2 = np.array([[4.0, 5.0, 6.0]])
-        v.set_data(data2, 0, 1)
-        assert np.array_equal(v.get_data(0, 1), data2)
-
-        # Test error cases
-        with pytest.raises(IndexError):
-            v[2, 0] = data1  # Out of bounds
+        assert isinstance(v[:2, 1], Vector)
+        assert v[:2, 1].shape == (2,)
+        assert v[1].shape == (2,)
+        assert v[1, 1].shape == ()
+        np.testing.assert_array_equal(v[-1, -1].array, np.array([[21.0, 121.0, 221.0]]))
 
         with pytest.raises(ValueError):
-            v[0, 0] = np.array([[1.0, 2.0]])  # Wrong number of fields
+            _ = v[:, 1].array
 
-        with pytest.raises(ValueError):
-            v.set_data(np.array([[1.0, 2.0]]), 0, 0)  # Wrong number of fields
+        result = v[[-1, 0], 1]
+        assert result.shape == (2,)
+        np.testing.assert_array_equal(result[0].array, np.array([[21.0, 121.0, 221.0]]))
+        np.testing.assert_array_equal(result[1].array, np.array([[1.0, 101.0, 201.0]]))
 
-    def test_field_operations(self):
-        """Test field-level operations."""
-        v = Vector.from_shape(shape=(2, 3), fields=["field0", "field1", "field2"])
+    def test_select_fields_and_chaining_equivalence(self):
+        v = make_line_vector()
 
-        # Set initial data
-        v[0, 0] = np.array([[1.0, 2.0, 3.0]])
-        v[0, 1] = np.array([[4.0, 5.0, 6.0]])
-        v[0, 2] = np.array([[7.0, 8.0, 9.0]])
+        selected = v.select_fields("kx")
+        assert selected.fields == ["kx"]
+        assert selected.units == ["px"]
+        assert selected.shape == v.shape
 
-        # Test field access
-        field_view = v["field0"]
-        assert (
-            hasattr(field_view, "vector")
-            and hasattr(field_view, "field_name")
-            and hasattr(field_view, "field_index")
+        np.testing.assert_array_equal(
+            v.select_fields("kx")[2].array,
+            v[2].select_fields("kx").array,
         )
 
-        # Test field operations
-        v["field0"] += 10  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 0)[:, 0], np.array([11.0]))  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 1)[:, 0], np.array([14.0]))  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 2)[:, 0], np.array([17.0]))  # type: ignore
-
-        # Test applying a function to a field
-        v["field1"] *= 2  # Using multiplication instead of lambda # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 0)[:, 1], np.array([4.0]))  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 1)[:, 1], np.array([10.0]))  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 2)[:, 1], np.array([16.0]))  # type: ignore
-
-        # Test field flattening
-        flat = v["field2"].flatten()
-        np.testing.assert_array_equal(flat, np.array([3.0, 6.0, 9.0]))  # type: ignore
-
-        # Test setting flattened data
-        v["field2"].set_flattened(np.array([18.0, 18.0, 18.0]))
-
-        # Test error cases
         with pytest.raises(KeyError):
-            v["nonexistent_field"]
-
-        with pytest.raises(ValueError):
-            v["field0"].set_flattened(np.array([1.0, 2.0]))  # Wrong length
-
-    def test_slicing(self):
-        """Test slicing operations."""
-        v = Vector.from_shape(shape=(4, 3), fields=["field0", "field1", "field2"])
-
-        # Set data
-        for i in range(4):
-            for j in range(3):
-                v[i, j] = np.array(
-                    [[float(i * 3 + j), float(i * 3 + j + 1), float(i * 3 + j + 2)]]
-                )
-
-        # Test slicing
-        sliced = v[1:3, 1]
-        assert isinstance(sliced, Vector)
-        assert sliced.shape == (2, 1)
-
-        # Compare arrays directly
-        expected1 = np.array([[4.0, 5.0, 6.0]])
-        expected2 = np.array([[7.0, 8.0, 9.0]])
-        np.testing.assert_array_equal(sliced.get_data(0, 0), expected1)  # type: ignore
-        np.testing.assert_array_equal(sliced.get_data(1, 0), expected2)  # type: ignore
-
-        # Test field access on sliced vector
-        field_sliced = sliced["field1"]
-        np.testing.assert_array_equal(field_sliced.flatten(), np.array([5.0, 8.0]))  # type: ignore
-
-        # Test copying slices of vectors
-        v[2:4, 1] = v[1:3, 1]
-
-        # Test copying slices of vectors with fancy indexing
-        v[[0, 1], 1] = v[[2, 3], 0]
-
-    def test_field_management(self):
-        """Test adding and removing fields."""
-        v = Vector.from_shape(shape=(2, 3), fields=["field0", "field1", "field2"])
-
-        # Set initial data
-        v[0, 0] = np.array([[1.0, 2.0, 3.0]])
-
-        # Test adding fields
-        v.add_fields(["field3", "field4"])
-        assert v.num_fields == 5
-        assert v.fields == ["field0", "field1", "field2", "field3", "field4"]
-        assert v.units == ["none", "none", "none", "none", "none"]
-
-        # Check that new fields are initialized to zeros
-        np.testing.assert_array_equal(v.get_data(0, 0)[:, 3:5], np.array([[0.0, 0.0]]))  # type: ignore
-
-        # Test removing fields
-        v.remove_fields(["field1", "field3"])
-        assert v.num_fields == 3
-        assert v.fields == ["field0", "field2", "field4"]
-        assert v.units == ["none", "none", "none"]
-
-        # Check that data is preserved for remaining fields
-        np.testing.assert_array_equal(v.get_data(0, 0)[:, 0], np.array([1.0]))  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 0)[:, 1], np.array([3.0]))  # type: ignore
-        np.testing.assert_array_equal(v.get_data(0, 0)[:, 2], np.array([0.0]))  # type: ignore
-
-        # Test error cases
-        with pytest.raises(ValueError):
-            v.add_fields(["field0"])  # Duplicate field
-
-        v.remove_fields(["nonexistent_field"])  # Should just print a warning
-
-    def test_copy(self):
-        """Test deep copying."""
-        v = Vector.from_shape(shape=(2, 3), fields=["field0", "field1", "field2"])
-        v[0, 0] = np.array([[1.0, 2.0, 3.0]])
-
-        # Create a copy
-        v_copy = v.copy()
-
-        # Check that it's a deep copy
-        assert v_copy is not v
-        assert v_copy.shape == v.shape
-        assert v_copy.fields == v.fields
-        assert v_copy.units == v.units
-        np.testing.assert_array_equal(v_copy.get_data(0, 0), v.get_data(0, 0))  # type: ignore
-
-        # Modify the copy and check that the original is unchanged
-        v_copy[0, 0] = np.array([[4.0, 5.0, 6.0]])
-        np.testing.assert_array_equal(v.get_data(0, 0), np.array([[1.0, 2.0, 3.0]]))  # type: ignore
-
-    def test_flatten(self):
-        """Test flattening the entire vector."""
-        v = Vector.from_shape(shape=(2, 3), fields=["field0", "field1", "field2"])
-
-        # Set data
-        v[0, 0] = np.array([[1.0, 2.0, 3.0]])
-        v[0, 1] = np.array([[4.0, 5.0, 6.0]])
-        v[0, 2] = np.array([[7.0, 8.0, 9.0]])
-        v[1, 0] = np.array([[10.0, 11.0, 12.0]])
-        v[1, 1] = np.array([[13.0, 14.0, 15.0]])
-        v[1, 2] = np.array([[16.0, 17.0, 18.0]])
-
-        # Flatten the vector
-        flattened = v.flatten()
-
-        # Check the flattened array
-        expected = np.array(
-            [
-                [1.0, 2.0, 3.0],
-                [4.0, 5.0, 6.0],
-                [7.0, 8.0, 9.0],
-                [10.0, 11.0, 12.0],
-                [13.0, 14.0, 15.0],
-                [16.0, 17.0, 18.0],
-            ]
-        )
-        np.testing.assert_array_equal(flattened, expected)  # type: ignore
-
-    def test_from_data(self):
-        """Test creating a Vector from ragged lists or numpy arrays."""
-        # Create test data
-        data = [
-            np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]),
-            np.array([[7.0, 8.0, 9.0]]),
-            np.array([[10.0, 11.0, 12.0], [13.0, 14.0, 15.0], [16.0, 17.0, 18.0]]),
-        ]
-
-        # Test with explicit fields
-        v1 = Vector.from_data(
-            data=data,
-            fields=["field0", "field1", "field2"],
-            name="test_vector",
-            units=["unit0", "unit1", "unit2"],
-        )
-
-        # Check properties
-        assert v1.shape == (3,)
-        assert v1.num_fields == 3
-        assert v1.fields == ["field0", "field1", "field2"]
-        assert v1.units == ["unit0", "unit1", "unit2"]
-        assert v1.name == "test_vector"
-
-        # Check data
-        np.testing.assert_array_equal(v1.get_data(0), data[0])  # type: ignore
-        np.testing.assert_array_equal(v1.get_data(1), data[1])  # type: ignore
-        np.testing.assert_array_equal(v1.get_data(2), data[2])  # type: ignore
-
-        # Test with inferred fields
-        v2 = Vector.from_data(data=data, num_fields=3)
-
-        # Check properties
-        assert v2.shape == (3,)
-        assert v2.num_fields == 3
-        assert v2.fields == ["field_0", "field_1", "field_2"]
-        assert v2.units == ["none", "none", "none"]
-
-        # Check data
-        np.testing.assert_array_equal(v2.get_data(0), data[0])  # type: ignore
-        np.testing.assert_array_equal(v2.get_data(1), data[1])  # type: ignore
-        np.testing.assert_array_equal(v2.get_data(2), data[2])  # type: ignore
-
-        # Test error cases
-        with pytest.raises(TypeError, match="Data must be a list"):
-            Vector.from_data(data=np.array([1, 2, 3]))  # type: ignore
-
-        with pytest.raises(ValueError, match="does not match length of fields"):
-            Vector.from_data(
-                data=data,
-                fields=["field0", "field1"],  # Wrong number of fields
-            )
-
-        with pytest.raises(ValueError, match="Duplicate field names"):
-            Vector.from_data(
-                data=data,
-                fields=["field0", "field0", "field2"],  # Duplicate field names
-            )
-
-    def test_fancy_indexing(self):
-        """Test fancy indexing with __getitem__ and __setitem__."""
-        v = Vector.from_shape(shape=(3, 2), fields=["field0", "field1", "field2"])
-
-        # Set initial data
-        v[0, 0] = np.array([[1.0, 2.0, 3.0]])
-        v[0, 1] = np.array([[4.0, 5.0, 6.0]])
-        v[1, 0] = np.array([[7.0, 8.0, 9.0]])
-        v[1, 1] = np.array([[10.0, 11.0, 12.0]])
-        v[2, 0] = np.array([[13.0, 14.0, 15.0]])
-        v[2, 1] = np.array([[16.0, 17.0, 18.0]])
-
-        # Test list indexing with __getitem__
-        result = v[[0, 1], 0]
-        assert isinstance(result, Vector)
-        assert result.shape == (2, 1)
-        np.testing.assert_array_equal(result.get_data(0, 0), np.array([[1.0, 2.0, 3.0]]))
-        np.testing.assert_array_equal(result.get_data(1, 0), np.array([[7.0, 8.0, 9.0]]))
-
-        # Test numpy array indexing with __getitem__
-        result = v[np.array([1, 2]), 1]  # type: ignore
-        assert isinstance(result, Vector)
-        assert result.shape == (2, 1)
-        np.testing.assert_array_equal(result.get_data(0, 0), np.array([[10.0, 11.0, 12.0]]))
-        np.testing.assert_array_equal(result.get_data(1, 0), np.array([[16.0, 17.0, 18.0]]))
-
-        # Test fancy indexing with __setitem__
-        new_data = [np.array([[20.0, 21.0, 22.0]]), np.array([[23.0, 24.0, 25.0]])]
-        v[[0, 2], 1] = new_data
-        np.testing.assert_array_equal(v.get_data(0, 1), new_data[0])
-        np.testing.assert_array_equal(v.get_data(2, 1), new_data[1])
-
-        # Test numpy array fancy indexing with __setitem__
-        new_data = [np.array([[26.0, 27.0, 28.0]]), np.array([[29.0, 30.0, 31.0]])]
-        v[np.array([1, 2]), 0] = new_data  # type: ignore
-        np.testing.assert_array_equal(v.get_data(1, 0), new_data[0])
-        np.testing.assert_array_equal(v.get_data(2, 0), new_data[1])
-
-        # Test error cases
-        with pytest.raises(IndexError):
-            v[[3, 4], 0]  # Index out of bounds
-
-        with pytest.raises(IndexError):
-            v[[0, 1], 2]  # Index out of bounds
-
-        with pytest.raises(ValueError):
-            v[[0, 1], 0] = [np.array([[1.0]])]  # Wrong number of arrays
-
-        with pytest.raises(ValueError):
-            v[[0, 1], 0] = [
-                np.array([[1.0]]),
-                np.array([[2.0]]),
-            ]  # Wrong number of fields
-
-    def test_get_data_methods(self):
-        """Test get_data method with various indexing scenarios."""
-        v = Vector.from_shape(shape=(3, 2), fields=["field0", "field1", "field2"])
-
-        # Set some test data
-        v[0, 0] = np.array([[1.0, 2.0, 3.0]])
-        v[0, 1] = np.array([[4.0, 5.0, 6.0]])
-        v[1, 0] = np.array([[7.0, 8.0, 9.0]])
-        v[1, 1] = np.array([[10.0, 11.0, 12.0]])
-        v[2, 0] = np.array([[13.0, 14.0, 15.0]])
-        v[2, 1] = np.array([[16.0, 17.0, 18.0]])
-
-        # Test single integer indexing
-        result = v.get_data(0, 0)
-        np.testing.assert_array_equal(result, np.array([[1.0, 2.0, 3.0]]))
-
-        # Test list indexing
-        result = v.get_data([0, 1], 0)
-        np.testing.assert_array_equal(result[0], np.array([[1.0, 2.0, 3.0]]))
-        np.testing.assert_array_equal(result[1], np.array([[7.0, 8.0, 9.0]]))
-
-        # Test numpy array indexing
-        result = v.get_data(np.array([1, 2]), 1)
-        np.testing.assert_array_equal(result[0], np.array([[10.0, 11.0, 12.0]]))
-        np.testing.assert_array_equal(result[1], np.array([[16.0, 17.0, 18.0]]))
-
-        # Test slice indexing
-        result = v.get_data(slice(1, 3), 0)
-        np.testing.assert_array_equal(result[0], np.array([[7.0, 8.0, 9.0]]))
-        np.testing.assert_array_equal(result[1], np.array([[13.0, 14.0, 15.0]]))
-
-        # Test error cases
-        with pytest.raises(ValueError, match="Expected 2 indices"):
-            v.get_data(0)  # Too few indices
-
-        with pytest.raises(ValueError, match="Expected 2 indices"):
-            v.get_data(0, 0, 0)  # Too many indices
-
-        with pytest.raises(IndexError):
-            v.get_data(3, 0)  # Index out of bounds
-
-        with pytest.raises(IndexError):
-            v.get_data([3, 4], 0)  # List index out of bounds
-
-    def test_set_data_methods(self):
-        """Test set_data method with various indexing scenarios."""
-        v = Vector.from_shape(shape=(3, 2), fields=["field0", "field1", "field2"])
-
-        # Test single integer indexing
-        data1 = np.array([[1.0, 2.0, 3.0]])
-        v.set_data(data1, 0, 0)
-        np.testing.assert_array_equal(v.get_data(0, 0), data1)
-
-        # Test list indexing
-        data2 = [np.array([[4.0, 5.0, 6.0]]), np.array([[7.0, 8.0, 9.0]])]
-        v.set_data(data2, [0, 1], 1)
-        np.testing.assert_array_equal(v.get_data(0, 1), data2[0])
-        np.testing.assert_array_equal(v.get_data(1, 1), data2[1])
-
-        # Test numpy array indexing
-        data3 = [np.array([[10.0, 11.0, 12.0]]), np.array([[13.0, 14.0, 15.0]])]
-        v.set_data(data3, np.array([1, 2]), 0)
-        np.testing.assert_array_equal(v.get_data(1, 0), data3[0])
-        np.testing.assert_array_equal(v.get_data(2, 0), data3[1])
-
-        # Test slice indexing
-        data4 = [np.array([[16.0, 17.0, 18.0]]), np.array([[19.0, 20.0, 21.0]])]
-        v.set_data(data4, slice(1, 3), 1)
-        np.testing.assert_array_equal(v.get_data(1, 1), data4[0])
-        np.testing.assert_array_equal(v.get_data(2, 1), data4[1])
-
-        # Test error cases
-        with pytest.raises(ValueError, match="Expected 2 indices"):
-            v.set_data(data1, 0)  # Too few indices
-
-        with pytest.raises(ValueError, match="Expected 2 indices"):
-            v.set_data(data1, 0, 0, 0)  # Too many indices
-
-        with pytest.raises(IndexError):
-            v.set_data(data1, 3, 0)  # Index out of bounds
-
-        with pytest.raises(IndexError):
-            v.set_data([data1, data1], [3, 4], 0)  # List index out of bounds
+            v.select_fields("missing")
 
         with pytest.raises(TypeError):
-            v.set_data([1, 2, 3], 0, 0)  # Invalid data type # type: ignore
+            _ = v["kx"]
 
-        with pytest.raises(ValueError):
-            v.set_data(np.array([[1.0]]), 0, 0)  # Wrong number of fields
+        with pytest.raises(TypeError):
+            _ = v[1, "kx"]
+
+    def test_array_mutation_writes_through_for_single_field(self):
+        v = make_line_vector()
+        cell = v.select_fields("kx")[1].array
+        cell[0, 0] = 99.0
+        assert v[1].array[0, 1] == 99.0
+
+    def test_field_arithmetic_with_scalar_and_ndarray(self):
+        v = make_line_vector()
+
+        kx = v.select_fields("kx")
+        kx += 10
+        np.testing.assert_array_equal(v.select_fields("kx").flatten(), np.array([[20.0], [30.0], [40.0], [50.0], [60.0], [70.0]]))
+
+        v.select_fields("kx")[...] += np.arange(6)
+        np.testing.assert_array_equal(v.select_fields("kx").flatten(), np.array([[20.0], [31.0], [42.0], [53.0], [64.0], [75.0]]))
+
+        summed = v.select_fields("intensity") + v.select_fields("ky")
+        np.testing.assert_array_equal(
+            summed.flatten(),
+            np.array([[101.0], [202.0], [303.0], [404.0], [505.0], [606.0]]),
+        )
+
+    def test_field_assignment_from_vector_expression(self):
+        v = make_line_vector()
+        scale = 2.5
+
+        v[:2].select_fields("intensity")[...] = v[2:4].select_fields("intensity") * scale
+        np.testing.assert_array_equal(
+            v[:2].select_fields("intensity").flatten(),
+            np.array([[10.0], [12.5], [15.0]]),
+        )
+
+    def test_field_assignment_requires_matching_per_cell_row_counts(self):
+        v = make_line_vector()
+        with pytest.raises(ValueError, match="Per-cell row counts must match"):
+            v[:2].select_fields("intensity")[...] = v[1:3].select_fields("intensity")
+
+    def test_full_cell_assignment_allows_row_count_changes(self):
+        v = make_line_vector()
+
+        v[1] = v[0]
+        assert v[1].array.shape == (2, 3)
+        np.testing.assert_array_equal(v[1].array, v[0].array)
+
+        v[0:2] = v[1:3]
+        assert v[0].array.shape == (2, 3)
+        assert v[1].array.shape == (2, 3)
+
+        broadcast_cell = np.array([[9.0, 8.0, 7.0]])
+        v[[0, 3]] = broadcast_cell
+        np.testing.assert_array_equal(v[0].array, broadcast_cell)
+        np.testing.assert_array_equal(v[3].array, broadcast_cell)
+
+    def test_boolean_indexing_is_axis_wise(self):
+        v = make_grid_vector()
+
+        rows = np.array([True, False, True])
+        cols = np.array([False, True])
+        selected = v[rows, cols]
+
+        assert selected.shape == (2, 1)
+        np.testing.assert_array_equal(selected[0, 0].array, np.array([[1.0, 101.0, 201.0]]))
+        np.testing.assert_array_equal(selected[1, 0].array, np.array([[21.0, 121.0, 221.0]]))
+
+        with pytest.raises(IndexError):
+            _ = v[np.array([[True, False], [False, True]])]
+
+    def test_empty_selection_is_valid_and_no_op_for_scalar_math(self):
+        v = make_grid_vector()
+        before = v.copy().flatten()
+
+        empty = v[[], :]
+        assert empty.shape == (0, 2)
+        assert empty.flatten().shape == (0, 3)
+
+        empty.select_fields("kx")[...] += 1
+        np.testing.assert_array_equal(v.flatten(), before)
+
+    def test_add_fields_defaults_expression_and_multiple_values(self):
+        v = make_line_vector()
+
+        v.add_fields(("h", "k"))
+        assert v.fields == ["intensity", "kx", "ky", "h", "k"]
+        assert np.isnan(v[0].array[:, 3:5]).all()
+
+        v.add_fields("field_out", v.select_fields("kx") + v.select_fields("ky"))
+        np.testing.assert_array_equal(
+            v.select_fields("field_out").flatten(),
+            np.array([[110.0], [220.0], [330.0], [440.0], [550.0], [660.0]]),
+        )
+
+        v2 = make_line_vector()
+        v2.add_fields(("h", "k"), (1.0, np.array([5.0, 6.0, 7.0, 8.0, 9.0, 10.0])))
+        np.testing.assert_array_equal(v2.select_fields("h").flatten(), np.ones((6, 1)))
+        np.testing.assert_array_equal(
+            v2.select_fields("k").flatten(),
+            np.array([[5.0], [6.0], [7.0], [8.0], [9.0], [10.0]]),
+        )
+
+    def test_remove_fields_preserves_remaining_data(self):
+        v = make_line_vector()
+        v.add_fields("extra", 1.0)
+        v.remove_fields(("kx", "extra"))
+
+        assert v.fields == ["intensity", "ky"]
+        np.testing.assert_array_equal(
+            v[0].array,
+            np.array([[1.0, 100.0], [2.0, 200.0]]),
+        )
+
+    def test_copy_is_deep(self):
+        v = make_line_vector()
+        v_copy = v.select_fields(["intensity", "kx"]).copy()
+
+        v_copy[0].array[0, 0] = -1.0
+        assert v[0].array[0, 0] == 1.0
+        assert v_copy.fields == ["intensity", "kx"]
+        assert v_copy.shape == (4,)
+
+    def test_from_data_supports_nested_fixed_grid(self):
+        data = [
+            [np.array([[1.0, 2.0]]), np.array([[3.0, 4.0], [5.0, 6.0]])],
+            [np.array([[7.0, 8.0]]), np.array([[9.0, 10.0]])],
+        ]
+        v = Vector.from_data(data=data, fields=["a", "b"], units=["u1", "u2"], name="nested")
+
+        assert v.shape == (2, 2)
+        assert v.fields == ["a", "b"]
+        assert v.units == ["u1", "u2"]
+        assert v.name == "nested"
+        np.testing.assert_array_equal(v[0, 1].array, np.array([[3.0, 4.0], [5.0, 6.0]]))
+
+        with pytest.raises(TypeError, match="Data must be a list"):
+            Vector.from_data(data=np.array([1, 2, 3]))  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError, match="same number of fields"):
+            Vector.from_data(data=[np.array([[1.0, 2.0]]), np.array([[1.0, 2.0, 3.0]])])

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -3,9 +3,8 @@ import zipfile
 import numpy as np
 import pytest
 
-from quantem.core.io.serialize import load
 from quantem.core.datastructures.vector import Vector
-
+from quantem.core.io.serialize import load
 
 
 def make_line_vector() -> Vector:
@@ -20,7 +19,6 @@ def make_line_vector() -> Vector:
     v[2] = np.array([[4.0, 40.0, 400.0], [5.0, 50.0, 500.0]])
     v[3] = np.array([[6.0, 60.0, 600.0]])
     return v
-
 
 
 def make_grid_vector() -> Vector:
@@ -138,10 +136,16 @@ class TestVector:
 
         kx = v.select_fields("kx")
         kx += 10
-        np.testing.assert_array_equal(v.select_fields("kx").flatten(), np.array([[20.0], [30.0], [40.0], [50.0], [60.0], [70.0]]))
+        np.testing.assert_array_equal(
+            v.select_fields("kx").flatten(),
+            np.array([[20.0], [30.0], [40.0], [50.0], [60.0], [70.0]]),
+        )
 
         v.select_fields("kx")[...] += np.arange(6)
-        np.testing.assert_array_equal(v.select_fields("kx").flatten(), np.array([[20.0], [31.0], [42.0], [53.0], [64.0], [75.0]]))
+        np.testing.assert_array_equal(
+            v.select_fields("kx").flatten(),
+            np.array([[20.0], [31.0], [42.0], [53.0], [64.0], [75.0]]),
+        )
 
         summed = v.select_fields("intensity") + v.select_fields("ky")
         np.testing.assert_array_equal(
@@ -221,7 +225,7 @@ class TestVector:
             np.sin(v.select_fields("kx").flatten()),
         )
 
-        maximum = np.maximum(v.select_fields("intensity"), 3.0)
+        maximum = np.maximum(v.select_fields("intensity"), 3.0)  # type: ignore[arg-type]
         np.testing.assert_array_equal(
             maximum.flatten(),
             np.array([[3.0], [3.0], [3.0], [4.0], [5.0], [6.0]]),
@@ -380,7 +384,11 @@ class TestVector:
             np.array([[5.0, 6.0], [7.0, 8.0], [9.0, 10.0]]),
         )
 
-        with pytest.raises(TypeError, match="Data must be a list"):
+        tuple_data = (np.array([[1.0, 2.0]]), np.array([[3.0, 4.0]]))
+        tuple_outer = Vector.from_data(data=tuple_data, fields=["a", "b"])
+        assert tuple_outer.shape == (2,)
+
+        with pytest.raises(TypeError, match="Data must be a list or tuple"):
             Vector.from_data(data=np.array([1, 2, 3]))  # type: ignore[arg-type]
 
         with pytest.raises(ValueError, match="same number of fields"):

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -37,7 +37,9 @@ class TestVector:
         v1 = Vector.from_shape(shape=(2, 3), fields=["a", "b", "c"])
         assert v1.shape == (2, 3)
         assert len(v1) == 2
+        assert v1.num_cells == 6
         assert v1.num_fields == 3
+        assert v1.dtype == np.dtype(float)
         assert v1.fields == ["a", "b", "c"]
         assert v1.units == ["none", "none", "none"]
         assert v1.name == "2d ragged array"
@@ -79,6 +81,7 @@ class TestVector:
 
         result = v[[-1, 0], 1]
         assert result.shape == (2,)
+        assert result.num_cells == 2
         np.testing.assert_array_equal(result[0].array, np.array([[21.0, 121.0, 221.0]]))
         np.testing.assert_array_equal(result[1].array, np.array([[1.0, 101.0, 201.0]]))
 
@@ -106,6 +109,7 @@ class TestVector:
 
         multi = v.select_fields("intensity", "kx")
         assert multi.fields == ["intensity", "kx"]
+        assert multi.dtype == np.dtype(float)
         assert multi.total_rows == 6
         assert multi.row_counts() == [2, 1, 2, 1]
 

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -104,11 +104,30 @@ class TestVector:
         with pytest.raises(TypeError):
             _ = v[1, "kx"]
 
+        multi = v.select_fields("intensity", "kx")
+        assert multi.fields == ["intensity", "kx"]
+        assert multi.total_rows == 6
+        assert multi.row_counts() == [2, 1, 2, 1]
+
     def test_array_mutation_writes_through_for_single_field(self):
         v = make_line_vector()
         cell = v.select_fields("kx")[1].array
         cell[0, 0] = 99.0
         assert v[1].array[0, 1] == 99.0
+
+    def test_set_flattened_updates_rowwise(self):
+        v = make_line_vector()
+        kx = v.select_fields("kx")
+
+        flat_kx = kx.flatten()
+        mask = flat_kx >= 30.0
+        flat_kx[mask[:, 0], 0] = -1.0
+        kx.set_flattened(flat_kx)
+
+        np.testing.assert_array_equal(
+            kx.flatten(),
+            np.array([[10.0], [20.0], [-1.0], [-1.0], [-1.0], [-1.0]]),
+        )
 
     def test_field_arithmetic_with_scalar_and_ndarray(self):
         v = make_line_vector()
@@ -156,6 +175,24 @@ class TestVector:
         v[[0, 3]] = broadcast_cell
         np.testing.assert_array_equal(v[0].array, broadcast_cell)
         np.testing.assert_array_equal(v[3].array, broadcast_cell)
+
+    def test_append_rows_and_compact(self):
+        v = make_line_vector()
+
+        v.append_rows(1, np.array([[7.0, 70.0, 700.0]]))
+        np.testing.assert_array_equal(
+            v[1].array,
+            np.array([[3.0, 30.0, 300.0], [7.0, 70.0, 700.0]]),
+        )
+
+        v[1] = np.array([[8.0, 80.0, 800.0]])
+        assert v._state["data"].shape[0] > v.total_rows
+
+        v.compact()
+        assert v._state["data"].shape[0] == v.total_rows
+
+        with pytest.raises(ValueError, match="exactly one cell"):
+            v.append_rows(slice(None), np.array([[1.0, 2.0, 3.0]]))
 
     def test_boolean_indexing_is_axis_wise(self):
         v = make_grid_vector()

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -1,6 +1,9 @@
+import zipfile
+
 import numpy as np
 import pytest
 
+from quantem.core.io.serialize import load
 from quantem.core.datastructures.vector import Vector
 
 
@@ -55,6 +58,12 @@ class TestVector:
 
         with pytest.raises(ValueError, match="Duplicate field names"):
             Vector.from_shape(shape=(2, 3), fields=["a", "a"])
+
+        assert str(v1) == (
+            "quantem.Vector, shape=(2, 3), name=2d ragged array\n"
+            "  fields = ['a', 'b', 'c']\n"
+            "  units: ['none', 'none', 'none']"
+        )
 
     def test_indexing_and_array_contract(self):
         v = make_grid_vector()
@@ -227,8 +236,40 @@ class TestVector:
         assert v.name == "nested"
         np.testing.assert_array_equal(v[0, 1].array, np.array([[3.0, 4.0], [5.0, 6.0]]))
 
+        tuple_cells = [
+            ([1.0, 2.0], [3.0, 4.0]),
+            ([5.0, 6.0], [7.0, 8.0], [9.0, 10.0]),
+        ]
+        tuple_vector = Vector.from_data(data=tuple_cells, fields=["a", "b"])
+        assert tuple_vector.shape == (2,)
+        np.testing.assert_array_equal(tuple_vector[0].array, np.array([[1.0, 2.0], [3.0, 4.0]]))
+        np.testing.assert_array_equal(
+            tuple_vector[1].array,
+            np.array([[5.0, 6.0], [7.0, 8.0], [9.0, 10.0]]),
+        )
+
         with pytest.raises(TypeError, match="Data must be a list"):
             Vector.from_data(data=np.array([1, 2, 3]))  # type: ignore[arg-type]
 
         with pytest.raises(ValueError, match="same number of fields"):
             Vector.from_data(data=[np.array([[1.0, 2.0]]), np.array([[1.0, 2.0, 3.0]])])
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        v = make_grid_vector()
+        v.add_fields("extra", v.select_fields("intensity") + 1.0)
+
+        path = tmp_path / "vector_test.zip"
+        v.save(path, mode="o", compression_level=4)
+
+        with zipfile.ZipFile(path) as zf:
+            names = [info.filename for info in zf.infolist()]
+        assert len(names) < 30
+        assert "_state/data/zarr.json" in names
+        assert all(not name.startswith("_selection_coords/") for name in names)
+
+        loaded = load(path)
+        assert isinstance(loaded, Vector)
+        assert loaded.shape == v.shape
+        assert loaded.fields == v.fields
+        assert loaded.units == v.units
+        np.testing.assert_array_equal(loaded[2, 1].array, v[2, 1].array)

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -203,6 +203,9 @@ class TestVector:
             np.array([[5.0], [6.0], [7.0], [8.0], [9.0], [10.0]]),
         )
 
+        with pytest.raises(ValueError, match="all fields are selected"):
+            v2.select_fields("kx").add_fields("bad")
+
     def test_remove_fields_preserves_remaining_data(self):
         v = make_line_vector()
         v.add_fields("extra", 1.0)

--- a/tests/datastructures/test_vector.py
+++ b/tests/datastructures/test_vector.py
@@ -149,6 +149,94 @@ class TestVector:
             np.array([[101.0], [202.0], [303.0], [404.0], [505.0], [606.0]]),
         )
 
+    def test_power_operations(self):
+        v = make_line_vector()
+
+        squared = v.select_fields("intensity") ** 2
+        np.testing.assert_array_equal(
+            squared.flatten(),
+            np.array([[1.0], [4.0], [9.0], [16.0], [25.0], [36.0]]),
+        )
+
+        intensity = v.select_fields("intensity")
+        intensity **= 2
+        np.testing.assert_array_equal(
+            intensity.flatten(),
+            np.array([[1.0], [4.0], [9.0], [16.0], [25.0], [36.0]]),
+        )
+
+        reverse = 2 ** v.select_fields("intensity")
+        np.testing.assert_array_equal(
+            reverse.flatten(),
+            np.array([[2.0], [16.0], [512.0], [65536.0], [33554432.0], [68719476736.0]]),
+        )
+
+    def test_unary_mod_and_floor_division_operations(self):
+        v = make_line_vector()
+
+        negative = -v.select_fields("intensity")
+        np.testing.assert_array_equal(
+            negative.flatten(),
+            np.array([[-1.0], [-2.0], [-3.0], [-4.0], [-5.0], [-6.0]]),
+        )
+
+        absolute = abs(negative)
+        np.testing.assert_array_equal(
+            absolute.flatten(),
+            np.array([[1.0], [2.0], [3.0], [4.0], [5.0], [6.0]]),
+        )
+
+        floored = v.select_fields("ky") // 150
+        np.testing.assert_array_equal(
+            floored.flatten(),
+            np.array([[0.0], [1.0], [2.0], [2.0], [3.0], [4.0]]),
+        )
+
+        modded = v.select_fields("ky") % 150
+        np.testing.assert_array_equal(
+            modded.flatten(),
+            np.array([[100.0], [50.0], [0.0], [100.0], [50.0], [0.0]]),
+        )
+
+        ky = v.select_fields("ky")
+        ky //= 150
+        np.testing.assert_array_equal(
+            ky.flatten(),
+            np.array([[0.0], [1.0], [2.0], [2.0], [3.0], [4.0]]),
+        )
+
+        intensity = v.select_fields("intensity")
+        intensity %= 2
+        np.testing.assert_array_equal(
+            intensity.flatten(),
+            np.array([[1.0], [0.0], [1.0], [0.0], [1.0], [0.0]]),
+        )
+
+    def test_numpy_ufunc_support(self):
+        v = make_line_vector()
+
+        sine = np.sin(v.select_fields("kx"))
+        np.testing.assert_allclose(
+            sine.flatten(),
+            np.sin(v.select_fields("kx").flatten()),
+        )
+
+        maximum = np.maximum(v.select_fields("intensity"), 3.0)
+        np.testing.assert_array_equal(
+            maximum.flatten(),
+            np.array([[3.0], [3.0], [3.0], [4.0], [5.0], [6.0]]),
+        )
+
+        frac, whole = np.modf(v.select_fields("intensity") / 2.0)
+        np.testing.assert_allclose(
+            frac.flatten(),
+            np.array([[0.5], [0.0], [0.5], [0.0], [0.5], [0.0]]),
+        )
+        np.testing.assert_allclose(
+            whole.flatten(),
+            np.array([[0.0], [1.0], [1.0], [2.0], [2.0], [3.0]]),
+        )
+
     def test_field_assignment_from_vector_expression(self):
         v = make_line_vector()
         scale = 2.5

--- a/tests/visualization/test_visualization_utils.py
+++ b/tests/visualization/test_visualization_utils.py
@@ -297,3 +297,11 @@ class TestBilinearHistogram2D:
         hist = bilinear_histogram_2d(shape, x, y, weight, statistic="mean")
         assert hist.shape == shape
         assert np.all(~np.isnan(hist[hist > 0]))  # Only check non-zero values for NaN
+
+    def test_bilinear_histogram_2d_accepts_column_vectors(self):
+        shape = (8, 8)
+        x = np.array([[1.0], [2.0], [3.0]])
+        y = np.array([[1.5], [2.5], [3.5]])
+        weight = np.array([[2.0], [3.0], [4.0]])
+        hist = bilinear_histogram_2d(shape, x, y, weight)
+        assert hist.shape == shape


### PR DESCRIPTION
# What this PR does

This PR completely rewrites the `Vector` class.

The new implementation is substantially simpler. Public proxy types such as `FieldView` and `CellView` are removed, and all indexing/selection operations now return `Vector`. The explicit NumPy escape hatches are:
- `.flatten()` for concatenated rowwise data
- `.array` for selections containing exactly one cell

The main syntax change is field selection. Instead of:
`v["kx"]`
use:
`v.select_fields("kx")`

This makes fixed-grid indexing with `[]` distinct from field selection.

`select_fields(...)` returns a write-through `Vector` view, so field-selected updates still modify the parent `Vector`.

This PR also adds:
- rowwise update helpers such as `set_flattened(...)`
- `append_rows(...)` and `compact()`
- expanded arithmetic support, including `**`, `%`, `//`, unary `-`, `abs(...)`
- elementwise NumPy ufunc support such as `np.sin(vector)` and `np.maximum(vector, 0)`
- Minor fix for the 2D histogram calculation function.

File I/O is also much cleaner. The internal storage no longer serializes nested per-cell containers, which previously created large Zarr metadata overhead. The new layout stores one numeric row buffer plus per-cell offsets/lengths. In practice this makes `Vector` saves substantially smaller and reduces read/write overhead.

# What PR reviewer(s) should do

- Run the `Vector` test suite and confirm downstream tests still behave as expected.
- Run the attached notebook examples.
- Call out any missing functionality or awkward syntax before this API is finalized.

# Notebook demo for syntax:
[vector_new_01.ipynb](https://github.com/user-attachments/files/25698793/vector_new_01.ipynb)

