### PR TITLE
Show 2d dataclass overhaul

### DIFF
--- a/src/quantem/core/utils/validators.py
+++ b/src/quantem/core/utils/validators.py
@@ -10,8 +10,9 @@ from quantem.core import config
 from quantem.core.utils import array_funcs as af
 
 if TYPE_CHECKING:
-    import cupy as cp
+    import cupy as cp  # type: ignore
     import torch
+
     TensorLike: TypeAlias = ArrayLike | torch.Tensor
 else:
     TensorLike: TypeAlias = ArrayLike
@@ -20,9 +21,10 @@ else:
     if config.get("has_cupy"):
         import cupy as cp
 
+
 # --- Dataset Validation Functions ---
 def ensure_valid_array(
-    array: "np.ndarray | cp.ndarray", dtype: DTypeLike = None, ndim: int | None = None
+    array: "np.ndarray | cp.ndarray", dtype: DTypeLike | None = None, ndim: int | None = None
 ) -> Union[np.ndarray, "cp.ndarray"]:
     """
     Ensure input is a numpy array or cupy array (if available), converting if necessary.
@@ -356,6 +358,17 @@ def validate_gt(
             raise ValueError(f"{name} must be greater than or equal to {cutoff}, got {value}")
     elif value <= cutoff:
         raise ValueError(f"{name} must be greater than {cutoff}, got {value}")
+    return value
+
+
+def validate_lt(
+    value: float | int, cutoff: float | int, name: str, leq: bool = False
+) -> float | int:
+    if leq:  # less than or equal to
+        if value > cutoff:
+            raise ValueError(f"{name} must be less than or equal to {cutoff}, got {value}")
+    elif value >= cutoff:
+        raise ValueError(f"{name} must be less than {cutoff}, got {value}")
     return value
 
 

--- a/src/quantem/core/visualization/__init__.py
+++ b/src/quantem/core/visualization/__init__.py
@@ -2,6 +2,7 @@ from quantem.core.visualization.custom_normalizations import (
     CustomNormalization as CustomNormalization,
     NormalizationConfig as NormalizationConfig,
 )
+from quantem.core.visualization.show_params import ShowParams as ShowParams
 from quantem.core.visualization.visualization import show_2d as show_2d
 from quantem.core.visualization.visualization_utils import (
     ScalebarConfig as ScalebarConfig,

--- a/src/quantem/core/visualization/__init__.py
+++ b/src/quantem/core/visualization/__init__.py
@@ -9,3 +9,4 @@ from quantem.core.visualization.visualization_utils import (
     turbo_black as turbo_black,
     axes_with_inset as axes_with_inset,
 )
+from quantem.core.visualization.line_scan import linescan as linescan

--- a/src/quantem/core/visualization/custom_normalizations.py
+++ b/src/quantem/core/visualization/custom_normalizations.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 from matplotlib import colors
@@ -461,8 +462,8 @@ class CustomNormalization(colors.Normalize):
 
     def __init__(
         self,
-        interval_type: str = "quantile",
-        stretch_type: str = "linear",
+        interval_type: Literal["quantile", "manual", "centered"] = "quantile",
+        stretch_type: Literal["linear", "power", "logarithmic", "asinh"] = "linear",
         *,
         data: NDArray | None = None,
         lower_quantile: float = 0.02,
@@ -599,8 +600,8 @@ class NormalizationConfig:
         Linear range for "asinh" stretch type.
     """
 
-    interval_type: str = "quantile"
-    stretch_type: str = "linear"
+    interval_type: Literal["quantile", "manual", "centered"] = "quantile"
+    stretch_type: Literal["linear", "power", "logarithmic", "asinh"] = "linear"
     lower_quantile: float = 0.02
     upper_quantile: float = 0.98
     vmin: float | None = None
@@ -673,5 +674,7 @@ def _resolve_normalization(norm, **kwargs) -> NormalizationConfig:
         return NORMALIZATION_PRESETS[norm]()
     elif isinstance(norm, NormalizationConfig):
         return norm
+    elif hasattr(norm, "to_config"):
+        return norm.to_config()
     else:
-        raise TypeError("norm must be None, dict, str, or NormalizationConfig")
+        raise TypeError("norm must be None, dict, str, NormalizationConfig, or ShowParams.Norm")

--- a/src/quantem/core/visualization/line_scan.py
+++ b/src/quantem/core/visualization/line_scan.py
@@ -19,7 +19,7 @@ def linescan(
     sampling: tuple[float, float] | np.ndarray | None = None,
     sampling_units: str | None = None,
     **kwargs,
-) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, tuple[Any, Any]]:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Generate a line scan through an image.
 
@@ -111,7 +111,7 @@ def linescan(
         sampling_units = "pixels"
 
     if show:
-        fig, axs = _show_linescan(
+        _fig, _axs = _show_linescan(
             scan_image,
             profile,
             positions,
@@ -121,13 +121,8 @@ def linescan(
             sampling_units,
             **kwargs,
         )
-    else:
-        fig, axs = None, None
 
-    if kwargs.get("return_fig", False) and show:
-        return positions, profile, (fig, axs)
-    else:
-        return positions, profile
+    return positions, profile
 
 
 def _calculate_line_endpoints(

--- a/src/quantem/core/visualization/line_scan.py
+++ b/src/quantem/core/visualization/line_scan.py
@@ -9,6 +9,7 @@ from quantem.core.visualization import show_2d
 
 
 # TODO update sampling to allow for 3D and to plot with appropriate units along xy/z
+# TODO proper normalization for line going through edges/corner with finite linewidth
 def linescan(
     image: np.ndarray,
     center: tuple[int, int] | None = None,
@@ -234,11 +235,13 @@ def _show_linescan(
 
     if profile.ndim == 1:
         ax0.plot(positions, profile, linewidth=2)
+        title = "Image"
     else:
         # For 3D input, show as image
         # im = ax0.imshow(profile, aspect="equal", origin="upper")
-        im = ax0.imshow(profile, aspect="auto", origin="upper")
+        im = ax0.matshow(profile, aspect="auto", origin="upper")
         plt.colorbar(im, ax=ax0)
+        title = "Mean of depth slices"
 
     ax0.set_xlabel(f"Position ({sampling_units})")
     ax0.set_ylabel("Intensity" if profile.ndim == 1 else "Depth (pixels)")
@@ -259,7 +262,7 @@ def _show_linescan(
 
     ax1.set_xlim(0, image.shape[1] - 1)
     ax1.set_ylim(image.shape[0] - 1, 0)
-    ax1.set_title("Image with Line Scan")
+    ax1.set_title(title)
 
     plt.tight_layout()
     return fig, (ax0, ax1)

--- a/src/quantem/core/visualization/show_params.py
+++ b/src/quantem/core/visualization/show_params.py
@@ -1,0 +1,189 @@
+from dataclasses import dataclass, fields
+from typing import Literal, Optional
+
+from quantem.core.visualization.custom_normalizations import NormalizationConfig
+from quantem.core.visualization.visualization_utils import ScalebarConfig
+
+
+class ShowParams:
+    """
+    Container for ``show_2d`` parameter dataclasses.
+
+    Nested classes
+    --------------
+    Norm
+        Normalization configuration (interval + stretch).
+    Scalebar
+        Scale bar overlay configuration.
+
+    Examples
+    --------
+    >>> show_2d(img, norm=ShowParams.Norm(power=0.5))
+    >>> show_2d(img, scalebar=ShowParams.Scalebar(sampling=0.5, units="Å"))
+    >>> show_2d(dp, norm=ShowParams.Norm.log_auto(), cbar=True, cmap="turbo")
+    """
+
+    @dataclass
+    class Norm:
+        """
+        Normalization parameters for ``show_2d``.
+
+        Controls how pixel values are mapped to the [0, 1] display range via
+        an *interval* (which values to keep) and a *stretch* (non-linear
+        transfer function).
+
+        If ``vmin`` or ``vmax`` is set and ``interval_type`` is left as the
+        default ``"quantile"``, it is automatically changed to ``"manual"``.
+        Likewise, setting ``vcenter`` to a non-zero value or providing
+        ``half_range`` auto-selects ``"centered"``.
+
+        Parameters
+        ----------
+        interval_type : ``"quantile"`` | ``"manual"`` | ``"centered"``
+            How to determine the data range.
+        stretch_type : ``"linear"`` | ``"power"`` | ``"logarithmic"`` | ``"asinh"``
+            Transfer function applied after interval mapping.
+        lower_quantile : float
+            Lower quantile for ``"quantile"`` interval. Default 0.02.
+        upper_quantile : float
+            Upper quantile for ``"quantile"`` interval. Default 0.98.
+        vmin : float or None
+            Explicit minimum for ``"manual"`` interval.
+        vmax : float or None
+            Explicit maximum for ``"manual"`` interval.
+        vcenter : float
+            Centre value for ``"centered"`` interval. Default 0.0.
+        half_range : float or None
+            Symmetric half-range for ``"centered"`` interval.
+        power : float
+            Exponent for ``"power"`` stretch (e.g. 0.5 = sqrt). Default 1.0.
+        logarithmic_index : float
+            Index *a* for ``"logarithmic"`` stretch: ``log(a*x+1)/log(a+1)``.
+            Default 1000.
+        asinh_linear_range : float
+            Transition parameter *a* for ``"asinh"`` stretch. Default 0.1.
+
+        Examples
+        --------
+        >>> ShowParams.Norm()                        # quantile + linear (default)
+        >>> ShowParams.Norm(power=0.5)               # quantile + sqrt stretch
+        >>> ShowParams.Norm(vmin=0, vmax=1000)       # auto → manual range
+        >>> ShowParams.Norm.log_auto()               # quantile + log stretch
+        >>> ShowParams.Norm.centered(half_range=5)   # centered ± 5, linear
+        """
+
+        interval_type: Literal["quantile", "manual", "centered"] = "quantile"
+        stretch_type: Literal["linear", "power", "logarithmic", "asinh"] = "linear"
+        lower_quantile: float = 0.02
+        upper_quantile: float = 0.98
+        vmin: Optional[float] = None
+        vmax: Optional[float] = None
+        vcenter: float = 0.0
+        half_range: Optional[float] = None
+        power: float = 1.0
+        logarithmic_index: float = 1000.0
+        asinh_linear_range: float = 0.1
+
+        def __post_init__(self) -> None:
+            if self.interval_type != "quantile":
+                return
+            if self.vmin is not None or self.vmax is not None:
+                self.interval_type = "manual"
+            elif self.vcenter != 0.0 or self.half_range is not None:
+                self.interval_type = "centered"
+
+        def to_config(self) -> NormalizationConfig:
+            """Convert to a ``NormalizationConfig``."""
+            return NormalizationConfig(**{f.name: getattr(self, f.name) for f in fields(self)})
+
+        # ---- presets (mirror NORMALIZATION_PRESETS) ----
+
+        @classmethod
+        def linear_auto(cls, **kw) -> "ShowParams.Norm":
+            """Quantile interval + linear stretch (the default)."""
+            return cls(**kw)
+
+        @classmethod
+        def minmax(cls, **kw) -> "ShowParams.Norm":
+            """Full min/max interval + linear stretch."""
+            return cls(interval_type="manual", **kw)
+
+        @classmethod
+        def centered(
+            cls, vcenter: float = 0.0, half_range: Optional[float] = None, **kw
+        ) -> "ShowParams.Norm":
+            """Centered interval + linear stretch."""
+            return cls(interval_type="centered", vcenter=vcenter, half_range=half_range, **kw)
+
+        @classmethod
+        def log_auto(cls, **kw) -> "ShowParams.Norm":
+            """Quantile interval + logarithmic stretch."""
+            return cls(stretch_type="logarithmic", **kw)
+
+        @classmethod
+        def log_minmax(cls, **kw) -> "ShowParams.Norm":
+            """Full min/max interval + logarithmic stretch."""
+            return cls(interval_type="manual", stretch_type="logarithmic", **kw)
+
+        @classmethod
+        def power_sqrt(cls, **kw) -> "ShowParams.Norm":
+            """Quantile interval + square-root (power=0.5) stretch."""
+            return cls(stretch_type="power", power=0.5, **kw)
+
+        @classmethod
+        def power_squared(cls, **kw) -> "ShowParams.Norm":
+            """Quantile interval + squared (power=2.0) stretch."""
+            return cls(stretch_type="power", power=2.0, **kw)
+
+        @classmethod
+        def asinh_centered(cls, vcenter: float = 0.0, **kw) -> "ShowParams.Norm":
+            """Centered interval + asinh stretch."""
+            return cls(interval_type="centered", stretch_type="asinh", vcenter=vcenter, **kw)
+
+    @dataclass
+    class Scalebar:
+        """
+        Scale bar parameters for ``show_2d``.
+
+        Parameters
+        ----------
+        sampling : float
+            Physical units per pixel. Default 1.0.
+        units : str
+            Unit label displayed on the scale bar (e.g. ``"Å"``, ``"nm"``,
+            ``"1/Å"``). Default ``"pixels"``.
+        length : float or None
+            Fixed scale bar length in physical units. ``None`` auto-estimates
+            a "nice" length.
+        width_px : float
+            Thickness of the bar in image pixels. Default 1.
+        pad_px : float
+            Padding between bar and plot edge in image pixels. Default 0.5.
+        color : str
+            Bar and label colour. Default ``"white"``.
+        loc : ``"lower right"`` | ``"lower left"`` | ``"upper right"`` | ``"upper left"``
+            Anchor location. Default ``"lower right"``.
+        fontsize : int
+            Font size of the scale bar label in points. Default 12.
+        bold : bool
+            Whether to render the label in bold. Default True.
+
+        Examples
+        --------
+        >>> ShowParams.Scalebar(sampling=0.5, units="Å")
+        >>> ShowParams.Scalebar(sampling=0.02, units="1/Å", color="black", fontsize=16)
+        """
+
+        sampling: float = 1.0
+        units: str = "pixels"
+        length: Optional[float] = None
+        width_px: float = 1
+        pad_px: float = 0.5
+        color: str = "white"
+        loc: Literal["lower right", "lower left", "upper right", "upper left"] = "lower right"
+        fontsize: int = 12
+        bold: bool = False
+
+        def to_config(self) -> ScalebarConfig:
+            """Convert to a ``ScalebarConfig``."""
+            return ScalebarConfig(**{f.name: getattr(self, f.name) for f in fields(self)})

--- a/src/quantem/core/visualization/show_params.py
+++ b/src/quantem/core/visualization/show_params.py
@@ -1,6 +1,8 @@
+import warnings
 from dataclasses import dataclass, fields
 from typing import Literal, Optional
 
+from quantem.core.utils.validators import validate_gt, validate_lt
 from quantem.core.visualization.custom_normalizations import NormalizationConfig
 from quantem.core.visualization.visualization_utils import ScalebarConfig
 
@@ -72,7 +74,7 @@ class ShowParams:
         >>> ShowParams.Norm.centered(half_range=5)   # centered ± 5, linear
         """
 
-        interval_type: Literal["quantile", "manual", "centered"] = "quantile"
+        interval_type: Optional[Literal["quantile", "manual", "centered"]] = None
         stretch_type: Literal["linear", "power", "logarithmic", "asinh"] = "linear"
         lower_quantile: float = 0.02
         upper_quantile: float = 0.98
@@ -85,12 +87,91 @@ class ShowParams:
         asinh_linear_range: float = 0.1
 
         def __post_init__(self) -> None:
-            if self.interval_type != "quantile":
-                return
-            if self.vmin is not None or self.vmax is not None:
-                self.interval_type = "manual"
-            elif self.vcenter != 0.0 or self.half_range is not None:
-                self.interval_type = "centered"
+            manual_set = self.vmin is not None or self.vmax is not None
+            centered_set = self.vcenter != 0.0 or self.half_range is not None
+            quantile_set = self.lower_quantile != 0.02 or self.upper_quantile != 0.98
+            user_chose = self.interval_type is not None
+
+            # --- auto-infer interval_type when not explicitly provided ---
+            if not user_chose:
+                if manual_set and centered_set:
+                    warnings.warn(
+                        "Both vmin/vmax and vcenter/half_range were set; "
+                        "defaulting to interval_type='manual'.",
+                        stacklevel=2,
+                    )
+                    self.interval_type = "manual"
+                elif manual_set:
+                    self.interval_type = "manual"
+                elif centered_set:
+                    self.interval_type = "centered"
+                else:
+                    self.interval_type = "quantile"
+
+            # --- warn about ignored interval fields ---
+            if self.interval_type == "manual" and quantile_set:
+                warnings.warn(
+                    "lower_quantile/upper_quantile are ignored when interval_type='manual'.",
+                    stacklevel=2,
+                )
+            if self.interval_type == "manual" and centered_set:
+                warnings.warn(
+                    "vcenter/half_range are ignored when interval_type='manual'.",
+                    stacklevel=2,
+                )
+            if self.interval_type == "quantile" and manual_set:
+                warnings.warn(
+                    "vmin/vmax are ignored when interval_type='quantile'.",
+                    stacklevel=2,
+                )
+            if self.interval_type == "quantile" and centered_set:
+                warnings.warn(
+                    "vcenter/half_range are ignored when interval_type='quantile'.",
+                    stacklevel=2,
+                )
+            if self.interval_type == "centered" and manual_set:
+                warnings.warn(
+                    "vmin/vmax are ignored when interval_type='centered'.",
+                    stacklevel=2,
+                )
+            if self.interval_type == "centered" and quantile_set:
+                warnings.warn(
+                    "lower_quantile/upper_quantile are ignored when interval_type='centered'.",
+                    stacklevel=2,
+                )
+
+            # --- warn about ignored stretch fields ---
+            if self.power != 1.0 and self.stretch_type not in ("power", "linear"):
+                warnings.warn(
+                    f"power={self.power} is ignored when stretch_type='{self.stretch_type}'.",
+                    stacklevel=2,
+                )
+            if self.logarithmic_index != 1000.0 and self.stretch_type != "logarithmic":
+                warnings.warn(
+                    f"logarithmic_index={self.logarithmic_index} is ignored "
+                    f"when stretch_type='{self.stretch_type}'.",
+                    stacklevel=2,
+                )
+            if self.asinh_linear_range != 0.1 and self.stretch_type != "asinh":
+                warnings.warn(
+                    f"asinh_linear_range={self.asinh_linear_range} is ignored "
+                    f"when stretch_type='{self.stretch_type}'.",
+                    stacklevel=2,
+                )
+
+            # --- invalid value checks ---
+            if self.vmin is not None and self.vmax is not None:
+                validate_gt(self.vmax, self.vmin, "vmax", geq=False)
+            validate_gt(self.lower_quantile, 0, "lower_quantile", geq=True)
+            validate_gt(self.upper_quantile, self.lower_quantile, "upper_quantile")
+            validate_lt(self.upper_quantile, 1.0, "upper_quantile", leq=True)
+            if self.upper_quantile > 1.0:
+                raise ValueError(f"upper_quantile must be <= 1, got {self.upper_quantile}.")
+            if self.half_range is not None:
+                validate_gt(self.half_range, 0, "half_range", geq=True)
+            validate_gt(self.power, 0, "power")
+            validate_gt(self.logarithmic_index, 0, "logarithmic_index")
+            validate_gt(self.asinh_linear_range, 0, "asinh_linear_range")
 
         def to_config(self) -> NormalizationConfig:
             """Convert to a ``NormalizationConfig``."""
@@ -183,6 +264,13 @@ class ShowParams:
         loc: Literal["lower right", "lower left", "upper right", "upper left"] = "lower right"
         fontsize: int = 12
         bold: bool = False
+
+        def __post_init__(self) -> None:
+            validate_gt(self.sampling, 0, "sampling")
+            if self.length is not None:
+                validate_gt(self.length, 0, "length")
+            validate_gt(self.width_px, 0, "width_px")
+            validate_gt(self.fontsize, 0, "fontsize")
 
         def to_config(self) -> ScalebarConfig:
             """Convert to a ``ScalebarConfig``."""

--- a/src/quantem/core/visualization/show_params.py
+++ b/src/quantem/core/visualization/show_params.py
@@ -1,6 +1,6 @@
 import warnings
 from dataclasses import dataclass, fields
-from typing import Literal, Optional
+from typing import Literal
 
 from quantem.core.utils.validators import validate_gt, validate_lt
 from quantem.core.visualization.custom_normalizations import NormalizationConfig
@@ -74,14 +74,14 @@ class ShowParams:
         >>> ShowParams.Norm.centered(half_range=5)   # centered ± 5, linear
         """
 
-        interval_type: Optional[Literal["quantile", "manual", "centered"]] = None
+        interval_type: Literal["quantile", "manual", "centered"] | None = None
         stretch_type: Literal["linear", "power", "logarithmic", "asinh"] = "linear"
         lower_quantile: float = 0.02
         upper_quantile: float = 0.98
-        vmin: Optional[float] = None
-        vmax: Optional[float] = None
+        vmin: float | None = None
+        vmax: float | None = None
         vcenter: float = 0.0
-        half_range: Optional[float] = None
+        half_range: float | None = None
         power: float = 1.0
         logarithmic_index: float = 1000.0
         asinh_linear_range: float = 0.1
@@ -191,7 +191,7 @@ class ShowParams:
 
         @classmethod
         def centered(
-            cls, vcenter: float = 0.0, half_range: Optional[float] = None, **kw
+            cls, vcenter: float = 0.0, half_range: float | None = None, **kw
         ) -> "ShowParams.Norm":
             """Centered interval + linear stretch."""
             return cls(interval_type="centered", vcenter=vcenter, half_range=half_range, **kw)
@@ -257,7 +257,7 @@ class ShowParams:
 
         sampling: float = 1.0
         units: str = "pixels"
-        length: Optional[float] = None
+        length: float | None = None
         width_px: float = 1
         pad_px: float = 0.5
         color: str = "white"

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import os
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import Any, cast
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
+import torch
 from matplotlib import colors
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from numpy.typing import NDArray
@@ -30,22 +31,19 @@ from quantem.core.visualization.visualization_utils import (
     list_of_arrays_to_rgba,
 )
 
-if TYPE_CHECKING:
-    import torch
-
-ArrayLike = Union[NDArray, "torch.Tensor"]
+ArrayLike = NDArray | torch.Tensor
 
 
 def _show_2d_array(
     array: NDArray,
     *,
-    norm: Optional[Union[NormalizationConfig, ShowParams.Norm, dict, str]] = None,
-    scalebar: Optional[Union[ScalebarConfig, ShowParams.Scalebar, dict, bool]] = None,
-    cmap: Union[str, colors.Colormap] = "gray",
+    norm: NormalizationConfig | ShowParams.Norm | dict | str | None = None,
+    scalebar: ScalebarConfig | ShowParams.Scalebar | dict | bool | None = None,
+    cmap: str | colors.Colormap = "gray",
     chroma_boost: float = 1.0,
     cbar: bool = False,
-    title: Optional[str] = None,
-    figax: Optional[tuple[Any, Any]] = None,
+    title: str | None = None,
+    figax: tuple[Any, Any] | None = None,
     figsize: tuple[int, int] = (8, 8),
     show_ticks: bool = False,
     **kwargs: Any,
@@ -173,14 +171,14 @@ def _show_2d_array(
 def _show_2d_combined(
     list_of_arrays: Sequence[NDArray],
     *,
-    norm: Optional[Union[NormalizationConfig, ShowParams.Norm, dict, str]] = None,
-    scalebar: Optional[Union[ScalebarConfig, ShowParams.Scalebar, dict, bool]] = None,
-    cmap: Union[str, colors.Colormap] = "gray",
+    norm: NormalizationConfig | ShowParams.Norm | dict | str | None = None,
+    scalebar: ScalebarConfig | ShowParams.Scalebar | dict | bool | None = None,
+    cmap: str | colors.Colormap = "gray",
     chroma_boost: float = 1.0,
     cbar: bool = False,
-    figax: Optional[tuple[Any, Any]] = None,
+    figax: tuple[Any, Any] | None = None,
     figsize: tuple[int, int] = (8, 8),
-    title: Optional[str] = None,
+    title: str | None = None,
     show_ticks: bool = False,
     **kwargs: Any,
 ) -> tuple[Any, Any]:
@@ -285,7 +283,7 @@ def _show_2d_combined(
 
 
 def _normalize_show_input_to_grid(
-    arrays: Any,  # Union[NDArray, Sequence[NDArray], Sequence[Sequence[NDArray]]],
+    arrays: Any,  # NDArray | Sequence[NDArray] | Sequence[Sequence[NDArray]]
 ) -> list[list[NDArray]]:
     """Convert various input formats to a consistent grid format for visualization.
 

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -427,7 +427,11 @@ def _normalize_show_args_to_grid(
 def show_2d(
     arrays: Union[NDArray, Sequence[NDArray], Sequence[Sequence[NDArray]]],
     *,
-    norm: NormalizationConfig | dict | str | Sequence[dict | str] | None = None,
+    norm: NormalizationConfig
+    | dict
+    | str
+    | Sequence[dict | str]
+    | None = None,  # TODO: Revamp NormalizationConfig, ScalebarConfig with Dataclasses
     scalebar: ScalebarConfig | dict | bool | Sequence[bool | dict | None] | None = None,
     cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
+# from __future__ import annotations
 
 import os
 import warnings
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, Union, cast
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -31,7 +31,10 @@ from quantem.core.visualization.visualization_utils import (
     combine_arrays_to_rgba,
 )
 
-ArrayLike = NDArray | torch.Tensor
+if TYPE_CHECKING:
+    from quantem.core.datastructures import Dataset2d
+
+ArrayLike: TypeAlias = Union[NDArray, torch.Tensor, "Dataset2d"]  # union required here
 
 
 def _show_2d_array(
@@ -404,12 +407,14 @@ def _normalize_show_args_to_grid(
     | dict
     | str
     | Sequence[NormalizationConfig | ShowParams.Norm | dict | str]
+    | Sequence[Sequence[NormalizationConfig | ShowParams.Norm | dict | str]]
     | None = None,
     scalebar: ScalebarConfig
     | ShowParams.Scalebar
     | dict
     | bool
     | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
+    | Sequence[Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]]
     | None = None,
     cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
@@ -444,6 +449,7 @@ def _normalize_show_args_to_grid(
     return args
 
 
+# the type hinting is a bit of a mess, but not sure how to improve it
 def show_2d(
     arrays: ArrayLike | Sequence[ArrayLike] | Sequence[Sequence[ArrayLike]],
     *,
@@ -453,6 +459,7 @@ def show_2d(
         | dict
         | str
         | Sequence[NormalizationConfig | ShowParams.Norm | dict | str]
+        | Sequence[Sequence[NormalizationConfig | ShowParams.Norm | dict | str]]
         | None
     ) = None,
     scalebar: ScalebarConfig
@@ -460,6 +467,7 @@ def show_2d(
     | dict
     | bool
     | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
+    | Sequence[Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]]
     | None = None,
     cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -176,7 +176,6 @@ def _show_2d_combined(
     *,
     norm: NormalizationConfig | ShowParams.Norm | dict | str | None = None,
     scalebar: ScalebarConfig | ShowParams.Scalebar | dict | bool | None = None,
-    cmap: str | colors.Colormap = "gray",
     chroma_boost: float = 1.0,
     cbar: bool = False,
     figax: tuple[Any, Any] | None = None,
@@ -591,7 +590,22 @@ def show_2d(
     if kwargs.pop("combine_images", False):
         if nrows > 1:
             raise ValueError()
-        fig, axs = _show_2d_combined(grid[0], figax=figax, **kwargs)  # TODO pass args here
+        if isinstance(norm, Sequence):  # flatten norm
+            norm = norm[0] if not isinstance(norm[0], Sequence) else norm[0][0]
+        if isinstance(scalebar, Sequence):  # flatten scalebar
+            scalebar = scalebar[0] if not isinstance(scalebar[0], Sequence) else scalebar[0][0]
+        if isinstance(title, Sequence) and not isinstance(title, str):  # flatten title
+            title = title[0] if isinstance(title[0], str) else title[0][0]
+
+        fig, axs = _show_2d_combined(
+            grid[0],
+            norm=norm,
+            scalebar=scalebar,
+            figax=figax,
+            title=title,
+            figsize=kwargs.pop("figsize", axsize),
+            **kwargs,
+        )
     else:
         normalized_args = _normalize_show_args_to_grid(
             shape=(nrows, ncols),

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -36,12 +36,35 @@ if TYPE_CHECKING:
 
 ArrayLike: TypeAlias = Union[NDArray, torch.Tensor, "Dataset2d"]  # union required here
 
+# --- show_2d / grid broadcast inputs ---
+# There might be a cleaner way to do this, but better to have it here than in the functions
+NormInputCell: TypeAlias = NormalizationConfig | ShowParams.Norm | dict | str
+Show2dNormInput: TypeAlias = (
+    NormInputCell
+    | None
+    | Sequence[NormInputCell]
+    | Sequence[Sequence[NormInputCell]]
+)
+
+ScalebarInputCell: TypeAlias = ScalebarConfig | ShowParams.Scalebar | dict | bool | None
+Show2dScalebarInput: TypeAlias = (
+    ScalebarConfig
+    | ShowParams.Scalebar
+    | dict
+    | bool
+    | None
+    | Sequence[ScalebarInputCell]
+    | Sequence[Sequence[ScalebarInputCell]]
+)
+
+CmapType: TypeAlias = str | colors.Colormap 
+
 
 def _show_2d_array(
     array: NDArray,
     *,
-    norm: NormalizationConfig | ShowParams.Norm | dict | str | None = None,
-    scalebar: ScalebarConfig | ShowParams.Scalebar | dict | bool | None = None,
+    norm: NormInputCell | None = None,
+    scalebar: ScalebarInputCell = None,
     cmap: str | colors.Colormap = "gray",
     chroma_boost: float = 1.0,
     cbar: bool = False,
@@ -51,11 +74,9 @@ def _show_2d_array(
     show_ticks: bool = False,
     **kwargs: Any,
 ) -> tuple[Any, Any]:
-    """Display a 2D array as an image with optional colorbar and scalebar.
+    """Render a single 2D array (real or complex) with optional colorbar/scalebar.
 
-    This function visualizes a 2D array, handling both real and complex data.
-    For complex data, it displays amplitude and phase information using a
-    perceptually-uniform color representation.
+    Complex data uses amplitude + phase in a perceptually uniform RGB encoding.
 
     Parameters
     ----------
@@ -174,8 +195,8 @@ def _show_2d_array(
 def _show_2d_combined(
     list_of_arrays: Sequence[NDArray],
     *,
-    norm: NormalizationConfig | ShowParams.Norm | dict | str | None = None,
-    scalebar: ScalebarConfig | ShowParams.Scalebar | dict | bool | None = None,
+    norm: NormInputCell | None = None,
+    scalebar: ScalebarInputCell = None,
     chroma_boost: float = 1.0,
     cbar: bool = False,
     figax: tuple[Any, Any] | None = None,
@@ -184,7 +205,7 @@ def _show_2d_combined(
     show_ticks: bool = False,
     **kwargs: Any,
 ) -> tuple[Any, Any]:
-    """Display multiple 2D arrays as a single combined image.
+    """Fuse multiple 2D arrays into one RGB panel (``show_2d(..., combine_images=True)``).
 
     This function takes a list of 2D arrays and creates a single visualization
     where each array is assigned a unique color, and their amplitudes determine
@@ -401,24 +422,9 @@ def _norm_show_args(
 
 def _normalize_show_args_to_grid(
     shape: tuple[int, int],
-    norm: NormalizationConfig
-    | ShowParams.Norm
-    | dict
-    | str
-    | Sequence[NormalizationConfig | ShowParams.Norm | dict | str]
-    | Sequence[Sequence[NormalizationConfig | ShowParams.Norm | dict | str]]
-    | None = None,
-    scalebar: ScalebarConfig
-    | ShowParams.Scalebar
-    | dict
-    | bool
-    | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
-    | Sequence[Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]]
-    | None = None,
-    cmap: str
-    | colors.Colormap
-    | Sequence[str | colors.Colormap]
-    | Sequence[Sequence[str | colors.Colormap]] = "gray",
+    norm: Show2dNormInput = None,
+    scalebar: Show2dScalebarInput = None,
+    cmap: CmapType | Sequence[CmapType] | Sequence[Sequence[CmapType]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
     title: str | Sequence[str] | Sequence[Sequence[str]] | None = None,
     chroma_boost: float | Sequence[float] = 1.0,
@@ -451,30 +457,12 @@ def _normalize_show_args_to_grid(
     return args
 
 
-# the type hinting is a bit of a mess, but not sure how to improve it
 def show_2d(
     arrays: ArrayLike | Sequence[ArrayLike] | Sequence[Sequence[ArrayLike]],
     *,
-    norm: (
-        NormalizationConfig
-        | ShowParams.Norm
-        | dict
-        | str
-        | Sequence[NormalizationConfig | ShowParams.Norm | dict | str]
-        | Sequence[Sequence[NormalizationConfig | ShowParams.Norm | dict | str]]
-        | None
-    ) = None,
-    scalebar: ScalebarConfig
-    | ShowParams.Scalebar
-    | dict
-    | bool
-    | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
-    | Sequence[Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]]
-    | None = None,
-    cmap: str
-    | colors.Colormap
-    | Sequence[str | colors.Colormap]
-    | Sequence[Sequence[str | colors.Colormap]] = "gray",
+    norm: Show2dNormInput = None,
+    scalebar: Show2dScalebarInput = None,
+    cmap: CmapType | Sequence[CmapType] | Sequence[Sequence[CmapType]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
     title: str | Sequence[str] | Sequence[Sequence[str]] | None = None,
     figax: tuple[Any, Any] | None = None,
@@ -484,12 +472,8 @@ def show_2d(
 ) -> tuple[Any, Any]:
     """Display one or more 2D arrays in a grid layout.
 
-    This is the main visualization function that can display a single array,
-    a list of arrays, or a grid of arrays. It supports both individual and
-    combined visualization modes.
-
-    The display arguments, i.e. everything except figax and axsize, can be given as single values
-    or as sequences that will be broadcasted to the grid shape defined by the input arrays.
+    ``norm``, ``scalebar``, ``cmap``, ``cbar``, and ``title`` may be scalars or nested
+    sequences broadcast to the panel grid.
 
     Parameters
     ----------
@@ -558,35 +542,33 @@ def show_2d(
 
     Examples
     --------
-    Display a single image:
+    Typed normalization and scale bar (same information as str/dict forms):
 
     >>> import numpy as np
-    >>> from quantem.core.visualization import show_2d
-    >>> image = np.random.rand(256, 256)
-    >>> fig, ax = show_2d(image, axsize=(3, 3))
-
-    Display a 2-row grid with titles and a scale bar:
-
-    >>> image_rows = [[np.random.rand(128, 128) for _ in range(3)] for _ in range(2)]
-    >>> label_rows = [["BF", "ADF", "ABF"], ["HAADF", "DPC", "SSB"]]
-    >>> fig, axs = show_2d(
-    ...     image_rows,
-    ...     title=label_rows,
-    ...     cmap="gray",
-    ...     scalebar={"sampling": 0.5, "units": "Å"},
+    >>> from quantem.core.visualization import show_2d, ShowParams
+    >>> img = np.random.rand(128, 128)
+    >>> fig, ax = show_2d(
+    ...     img,
+    ...     norm=ShowParams.Norm.log_auto(),
+    ...     scalebar=ShowParams.Scalebar(sampling=0.5, units="Å"),
+    ...     cbar=True,
     ... )
 
-    Display diffraction patterns with log normalization, colorbar, and scale bar:
+    Preset strings and dicts:
 
-    >>> dps = [np.random.rand(256, 256) ** 3 for _ in range(3)]
     >>> fig, axs = show_2d(
-    ...     dps,
-    ...     title=["Zone axis", "Off-axis", "CBED"],
+    ...     [np.random.rand(64, 64) ** 3 for _ in range(3)],
     ...     norm="log_auto",
-    ...     cbar=True,
     ...     cmap="turbo",
+    ...     title=["a", "b", "c"],
     ...     scalebar={"sampling": 0.02, "units": "1/Å"},
     ... )
+
+    Multi-row grid with titles:
+
+    >>> rows = [[np.random.rand(48, 48) for _ in range(3)] for _ in range(2)]
+    >>> labels = [["BF", "ADF", "ABF"], ["HAADF", "DPC", "SSB"]]
+    >>> fig, axs = show_2d(rows, title=labels, cmap="gray", scalebar={"sampling": 0.5, "units": "Å"})
     """
     arrays = to_cpu(arrays)
     grid = _normalize_show_input_to_grid(arrays)

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -144,10 +144,10 @@ def _show_2d_array(
         cb_abs = add_cbar_to_ax(fig, ax_cb_abs, norm_obj, cmap_obj)
 
         if is_complex:
-            ax_cb_angle = divider.append_axes("right", size="5%", pad="10%")
+            ax_cb_angle = divider.append_axes("right", size="5%", pad="15%")
             add_arg_cbar_to_ax(fig, ax_cb_angle, chroma_boost=chroma_boost)
             cb_abs.set_label("abs", rotation=0, ha="center", va="bottom")
-            cb_abs.ax.yaxis.set_label_coords(0.5, -0.05)
+            cb_abs.ax.yaxis.set_label_coords(0.5, -0.07)
 
     if scalebar_config is not None:
         add_scalebar_to_ax(

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -131,10 +131,10 @@ def _show_2d_array(
 
     ax.imshow(rgba, interpolation=config.get("viz.interpolation"))
 
-    if show_ticks:
-        ax.set(title=title)
-    else:
-        ax.set(xticks=[], yticks=[], title=title)
+    if title is not None:
+        ax.set_title(title, fontsize=kwargs.get("title_fontsize", 12))
+    if not show_ticks:
+        ax.set(xticks=[], yticks=[])
 
     if cbar:
         divider = make_axes_locatable(ax)
@@ -258,10 +258,10 @@ def _show_2d_combined(
 
     ax.imshow(rgba, interpolation=config.get("viz.interpolation"))
 
-    if show_ticks:
-        ax.set(title=title)
-    else:
-        ax.set(xticks=[], yticks=[], title=title)
+    if title is not None:
+        ax.set_title(title, fontsize=kwargs.get("title_fontsize", 12))
+    if not show_ticks:
+        ax.set(xticks=[], yticks=[])
 
     if cbar:
         raise NotImplementedError()
@@ -415,7 +415,10 @@ def _normalize_show_args_to_grid(
     | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
     | Sequence[Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]]
     | None = None,
-    cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
+    cmap: str
+    | colors.Colormap
+    | Sequence[str | colors.Colormap]
+    | Sequence[Sequence[str | colors.Colormap]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
     title: str | Sequence[str] | Sequence[Sequence[str]] | None = None,
     chroma_boost: float | Sequence[float] = 1.0,
@@ -468,7 +471,10 @@ def show_2d(
     | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
     | Sequence[Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]]
     | None = None,
-    cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
+    cmap: str
+    | colors.Colormap
+    | Sequence[str | colors.Colormap]
+    | Sequence[Sequence[str | colors.Colormap]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
     title: str | Sequence[str] | Sequence[Sequence[str]] | None = None,
     figax: tuple[Any, Any] | None = None,

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -28,7 +28,7 @@ from quantem.core.visualization.visualization_utils import (
     add_cbar_to_ax,
     add_scalebar_to_ax,
     array_to_rgba,
-    list_of_arrays_to_rgba,
+    combine_arrays_to_rgba,
 )
 
 ArrayLike = NDArray | torch.Tensor
@@ -233,7 +233,7 @@ def _show_2d_combined(
         lower_quantile=norm_config.lower_quantile,
         upper_quantile=norm_config.upper_quantile,
         vmin=norm_config.vmin,
-        vmax=norm_config.vmin,
+        vmax=norm_config.vmax,
         vcenter=norm_config.vcenter,
         half_range=norm_config.half_range,
         power=norm_config.power,
@@ -243,7 +243,7 @@ def _show_2d_combined(
 
     # Convert Sequence to list for list_of_arrays_to_rgba
     list_of_arrays_list = list(list_of_arrays)
-    rgba = list_of_arrays_to_rgba(
+    rgba = combine_arrays_to_rgba(
         list_of_arrays_list,
         norm=norm_obj,
         chroma_boost=chroma_boost,

--- a/src/quantem/core/visualization/visualization.py
+++ b/src/quantem/core/visualization/visualization.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
 import warnings
 from collections.abc import Sequence
-from typing import Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -17,6 +19,7 @@ from quantem.core.visualization.custom_normalizations import (
     NormalizationConfig,
     _resolve_normalization,
 )
+from quantem.core.visualization.show_params import ShowParams
 from quantem.core.visualization.visualization_utils import (
     ScalebarConfig,
     _resolve_scalebar,
@@ -27,12 +30,17 @@ from quantem.core.visualization.visualization_utils import (
     list_of_arrays_to_rgba,
 )
 
+if TYPE_CHECKING:
+    import torch
+
+ArrayLike = Union[NDArray, "torch.Tensor"]
+
 
 def _show_2d_array(
     array: NDArray,
     *,
-    norm: Optional[Union[NormalizationConfig, dict, str]] = None,
-    scalebar: Optional[Union[ScalebarConfig, dict, bool]] = None,
+    norm: Optional[Union[NormalizationConfig, ShowParams.Norm, dict, str]] = None,
+    scalebar: Optional[Union[ScalebarConfig, ShowParams.Scalebar, dict, bool]] = None,
     cmap: Union[str, colors.Colormap] = "gray",
     chroma_boost: float = 1.0,
     cbar: bool = False,
@@ -151,6 +159,8 @@ def _show_2d_array(
             scalebar_config.pad_px,
             scalebar_config.color,
             scalebar_config.loc,
+            scalebar_config.fontsize,
+            scalebar_config.bold,
         )
 
     for spine in ax.spines.values():  # fixes asymmetry of bbox for some reason
@@ -163,8 +173,8 @@ def _show_2d_array(
 def _show_2d_combined(
     list_of_arrays: Sequence[NDArray],
     *,
-    norm: Optional[Union[NormalizationConfig, dict, str]] = None,
-    scalebar: Optional[Union[ScalebarConfig, dict, bool]] = None,
+    norm: Optional[Union[NormalizationConfig, ShowParams.Norm, dict, str]] = None,
+    scalebar: Optional[Union[ScalebarConfig, ShowParams.Scalebar, dict, bool]] = None,
     cmap: Union[str, colors.Colormap] = "gray",
     chroma_boost: float = 1.0,
     cbar: bool = False,
@@ -267,6 +277,8 @@ def _show_2d_combined(
             scalebar_config.pad_px,
             scalebar_config.color,
             scalebar_config.loc,
+            scalebar_config.fontsize,
+            scalebar_config.bold,
         )
 
     return fig, ax
@@ -389,8 +401,18 @@ def _norm_show_args(
 
 def _normalize_show_args_to_grid(
     shape: tuple[int, int],
-    norm: NormalizationConfig | dict | str | Sequence[dict | str] | None = None,
-    scalebar: ScalebarConfig | dict | bool | Sequence[bool | dict | None] | None = None,
+    norm: NormalizationConfig
+    | ShowParams.Norm
+    | dict
+    | str
+    | Sequence[NormalizationConfig | ShowParams.Norm | dict | str]
+    | None = None,
+    scalebar: ScalebarConfig
+    | ShowParams.Scalebar
+    | dict
+    | bool
+    | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
+    | None = None,
     cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
     title: str | Sequence[str] | Sequence[Sequence[str]] | None = None,
@@ -425,14 +447,22 @@ def _normalize_show_args_to_grid(
 
 
 def show_2d(
-    arrays: Union[NDArray, Sequence[NDArray], Sequence[Sequence[NDArray]]],
+    arrays: ArrayLike | Sequence[ArrayLike] | Sequence[Sequence[ArrayLike]],
     *,
-    norm: NormalizationConfig
+    norm: (
+        NormalizationConfig
+        | ShowParams.Norm
+        | dict
+        | str
+        | Sequence[NormalizationConfig | ShowParams.Norm | dict | str]
+        | None
+    ) = None,
+    scalebar: ScalebarConfig
+    | ShowParams.Scalebar
     | dict
-    | str
-    | Sequence[dict | str]
-    | None = None,  # TODO: Revamp NormalizationConfig, ScalebarConfig with Dataclasses
-    scalebar: ScalebarConfig | dict | bool | Sequence[bool | dict | None] | None = None,
+    | bool
+    | Sequence[ScalebarConfig | ShowParams.Scalebar | dict | bool | None]
+    | None = None,
     cmap: str | colors.Colormap | Sequence[str] | Sequence[Sequence[str]] = "gray",
     cbar: bool | Sequence[bool] | Sequence[Sequence[bool]] = False,
     title: str | Sequence[str] | Sequence[Sequence[str]] | None = None,

--- a/src/quantem/core/visualization/visualization_utils.py
+++ b/src/quantem/core/visualization/visualization_utils.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
-from typing import Any, List, Optional, Sequence, Tuple, Union, cast
+from typing import Any, cast
 
 import matplotlib as mpl
+import matplotlib.pyplot as plt
 import numpy as np
 from colorspacious import cspace_convert
 from matplotlib import cm, colors, legend, ticker
@@ -18,9 +19,9 @@ from quantem.core.visualization.custom_normalizations import CustomNormalization
 
 def array_to_rgba(
     scaled_amplitude: NDArray,
-    scaled_angle: Optional[NDArray] = None,
+    scaled_angle: NDArray | None = None,
     *,
-    cmap: Union[str, colors.Colormap] = "gray",
+    cmap: str | colors.Colormap = "gray",
     chroma_boost: float = 1,
 ) -> NDArray:
     """Convert amplitude and angle arrays to an RGBA color array.
@@ -73,7 +74,7 @@ def array_to_rgba(
 
 
 def list_of_arrays_to_rgba(
-    list_of_arrays: List[NDArray],
+    list_of_arrays: list[NDArray],
     *,
     norm: CustomNormalization = CustomNormalization(),
     chroma_boost: float = 1,
@@ -147,11 +148,11 @@ class ScalebarConfig:
 
     sampling: float = 1.0
     units: str = "pixels"
-    length: Optional[float] = None
+    length: float | None = None
     width_px: float = 1
     pad_px: float = 0.5
     color: str = "white"
-    loc: Union[str, int] = "lower right"
+    loc: str | int = "lower right"
     fontsize: int = 12
     bold: bool = False
 
@@ -162,7 +163,7 @@ SCALEBAR_KWARGS = [
 ]
 
 
-def _resolve_scalebar(cfg: Any, **kwargs) -> Optional[ScalebarConfig]:
+def _resolve_scalebar(cfg: Any, **kwargs) -> ScalebarConfig | None:
     """Resolve various input types to a ScalebarConfig object.
 
     Parameters
@@ -204,7 +205,7 @@ def _resolve_scalebar(cfg: Any, **kwargs) -> Optional[ScalebarConfig]:
         )
 
 
-def estimate_scalebar_length(length: float, sampling: float) -> Tuple[float, float]:
+def estimate_scalebar_length(length: float, sampling: float) -> tuple[float, float]:
     """Estimate an appropriate scale bar length based on data dimensions.
 
     This function calculates a "nice" scale bar length that is a multiple of
@@ -277,12 +278,12 @@ def add_scalebar_to_ax(
     ax: Axes,
     array_size: float,
     sampling: float,
-    length_units: Optional[float],
+    length_units: float | None,
     units: str,
     width_px: float,
     pad_px: float,
     color: str,
-    loc: Union[str, int],
+    loc: str | int,
     fontsize: int = 12,
     bold: bool = True,
 ) -> None:
@@ -444,7 +445,7 @@ def add_arg_cbar_to_ax(
     return cb_angle
 
 
-def turbo_black(num_colors: int = 256, fade_len: Optional[int] = None) -> colors.ListedColormap:
+def turbo_black(num_colors: int = 256, fade_len: int | None = None) -> colors.ListedColormap:
     """Create a modified version of the 'turbo' colormap that fades to black.
 
     This function creates a colormap based on the 'turbo' colormap but with
@@ -483,12 +484,12 @@ except ValueError:
 
 
 def bilinear_histogram_2d(
-    shape: Tuple[int, int],
+    shape: tuple[int, int],
     x: NDArray,
     y: NDArray,
     weight: NDArray,
-    origin: Tuple[float, float] = (0.0, 0.0),
-    sampling: Tuple[float, float] = (1.0, 1.0),
+    origin: tuple[float, float] = (0.0, 0.0),
+    sampling: tuple[float, float] = (1.0, 1.0),
     statistic: str = "sum",
 ) -> NDArray:
     """Create a 2D histogram with bilinear binning.
@@ -533,7 +534,7 @@ def bilinear_histogram_2d(
         )
 
     # Convert shape tuple to list for binned_statistic_2d
-    bins: Sequence[int] = [Nx, Ny]
+    bins: list[int] = [Nx, Ny]
     hist, _, _, _ = binned_statistic_2d(
         x,
         y,
@@ -568,7 +569,7 @@ def axes_with_inset(
     - Fractional inset by default (relative to main axes size).
     - Only the inset axes background is set to black (main axes stays default).
     """
-    fig, ax_main = mpl.pyplot.subplots(1, 1, figsize=axsize)
+    fig, ax_main = plt.subplots(1, 1, figsize=axsize)
 
     # lazy import here (some environments need it this way)
     from mpl_toolkits.axes_grid1.inset_locator import inset_axes

--- a/src/quantem/core/visualization/visualization_utils.py
+++ b/src/quantem/core/visualization/visualization_utils.py
@@ -499,7 +499,7 @@ def add_arg_cbar_to_ax(
     cb_angle = fig.colorbar(sm, cax=cax)
 
     cb_angle.set_label("arg", rotation=0, ha="center", va="bottom")
-    cb_angle.ax.yaxis.set_label_coords(0.5, -0.05)
+    cb_angle.ax.yaxis.set_label_coords(0.5, -0.07)
     cb_angle.set_ticks([-np.pi, -np.pi / 2, 0, np.pi / 2, np.pi])
     cb_angle.set_ticklabels(
         [r"$-\pi$", r"$-\dfrac{\pi}{2}$", "$0$", r"$\dfrac{\pi}{2}$", r"$\pi$"]

--- a/src/quantem/core/visualization/visualization_utils.py
+++ b/src/quantem/core/visualization/visualization_utils.py
@@ -73,7 +73,7 @@ def array_to_rgba(
     return rgba
 
 
-def list_of_arrays_to_rgba(
+def combine_arrays_to_rgba(
     list_of_arrays: list[NDArray],
     *,
     norm: CustomNormalization = CustomNormalization(),

--- a/src/quantem/core/visualization/visualization_utils.py
+++ b/src/quantem/core/visualization/visualization_utils.py
@@ -139,6 +139,10 @@ class ScalebarConfig:
     loc : str or int, default="lower right"
         Location of the scale bar on the plot. Can be a string like "lower right"
         or an integer location code.
+    fontsize : int, default=12
+        Font size of the scale bar label in points.
+    bold : bool, default=True
+        Whether to render the scale bar label in bold.
     """
 
     sampling: float = 1.0
@@ -148,6 +152,8 @@ class ScalebarConfig:
     pad_px: float = 0.5
     color: str = "white"
     loc: Union[str, int] = "lower right"
+    fontsize: int = 12
+    bold: bool = False
 
 
 SCALEBAR_KWARGS = [
@@ -190,8 +196,12 @@ def _resolve_scalebar(cfg: Any, **kwargs) -> Optional[ScalebarConfig]:
         return ScalebarConfig(**cfg)
     elif isinstance(cfg, ScalebarConfig):
         return cfg
+    elif hasattr(cfg, "to_config"):
+        return cfg.to_config()
     else:
-        raise TypeError("scalebar must be None, dict, bool, or ScalebarConfig")
+        raise TypeError(
+            "scalebar must be None, dict, bool, ScalebarConfig, or ShowParams.Scalebar"
+        )
 
 
 def estimate_scalebar_length(length: float, sampling: float) -> Tuple[float, float]:
@@ -273,6 +283,8 @@ def add_scalebar_to_ax(
     pad_px: float,
     color: str,
     loc: Union[str, int],
+    fontsize: int = 12,
+    bold: bool = True,
 ) -> None:
     """Add a scale bar to a matplotlib axis.
 
@@ -297,7 +309,13 @@ def add_scalebar_to_ax(
         Color of the scale bar.
     loc : str or int
         Location of the scale bar on the plot.
+    fontsize : int
+        Font size of the scale bar label in points.
+    bold : bool
+        Whether to render the scale bar label in bold.
     """
+    from matplotlib.font_manager import FontProperties
+
     if length_units is None:
         length_units, length_px = estimate_scalebar_length(array_size, sampling)
     else:
@@ -315,6 +333,8 @@ def add_scalebar_to_ax(
         loc_strings = {v: k for k, v in loc_codes.items()}
         loc = loc_strings[loc]
 
+    fontprops = FontProperties(size=fontsize, weight="bold" if bold else "normal")
+
     bar = AnchoredSizeBar(
         ax.transData,
         length_px,
@@ -324,7 +344,8 @@ def add_scalebar_to_ax(
         color=color,
         frameon=False,
         label_top=loc[:3] == "low",
-        size_vertical=int(width_px),  # Convert to int as required by AnchoredSizeBar
+        size_vertical=int(width_px),
+        fontproperties=fontprops,
     )
     ax.add_artist(bar)
 

--- a/src/quantem/core/visualization/visualization_utils.py
+++ b/src/quantem/core/visualization/visualization_utils.py
@@ -247,31 +247,92 @@ def estimate_scalebar_length(length: float, sampling: float) -> tuple[float, flo
 
 def _normalize_length_units(length_units: float, units: str) -> tuple[float, str]:
     """
-    pick intelligent units for the scalebar length
+    Pick intelligent units for the scalebar length. Handles both direct and inverse units.
     """
-    if units in ["A", "Å", "angstrom", "Angstrom"]:
-        length_A = length_units
-    elif units in ["nm", "nanometer", "nanometre"]:
-        length_A = length_units * 10
-    elif units in ["um", "μm", "micrometer", "micrometre"]:
-        length_A = length_units * 1e4
-    elif units in ["mm", "millimeter", "millimetre"]:
-        length_A = length_units * 1e7
-    elif units in ["cm", "centimeter", "centimetre"]:
-        length_A = length_units * 1e8
-    else:
-        return length_units, units
+    inverse_unit_map = {
+        "1/A": "$\\mathrm{Å}^{-1}$",
+        "1/Å": "$\\mathrm{Å}^{-1}$",
+        "A^-1": "$\\mathrm{Å}^{-1}$",
+        "1/angstrom": "$\\mathrm{Å}^{-1}$",
+        "1/Angstrom": "$\\mathrm{Å}^{-1}$",
+        "1/nm": "$\\mathrm{nm}^{-1}$",
+        "1/nanometer": "$\\mathrm{nm}^{-1}$",
+        "1/nanometre": "$\\mathrm{nm}^{-1}$",
+    }
+    direct_unit_map = {
+        "A": "Å",
+        "Å": "Å",
+        "angstrom": "Å",
+        "Angstrom": "Å",
+        "nm": "nm",
+        "nanometer": "nm",
+        "nanometre": "nm",
+        "um": "μm",
+        "μm": "μm",
+        "micrometer": "μm",
+        "micrometre": "μm",
+        "micron": "μm",
+        "mm": "mm",
+        "millimeter": "mm",
+        "millimetre": "mm",
+        "cm": "cm",
+        "centimeter": "cm",
+        "centimetre": "cm",
+        "m": "m",
+        "meter": "m",
+        "metre": "m",
+    }
 
-    if length_A < 0.1:
-        return length_A * 100, "pm"
-    elif length_A < 10:
-        return length_A, "Å"
-    elif length_A < 3e4:
-        return length_A / 10, "nm"
-    elif length_A < 1e7:
-        return length_A / 1e4, "μm"
-    else:
-        return length_A / 1e7, "mm"
+    # Handle inverse units first
+    if units in inverse_unit_map:
+        # Convert everything to 1/Å then scale
+        units = inverse_unit_map[units]
+        if units == "$\\mathrm{Å}^{-1}$":
+            length_invA = length_units
+        else:  # units == "$\\mathrm{nm}^{-1}$":
+            length_invA = length_units / 10
+
+        if length_invA < 0.1:
+            return length_invA * 10, "$\\mathrm{nm}^{-1}$"
+        elif length_invA < 100:
+            return length_invA, "$\\mathrm{Å}^{-1}$"
+        else:  # length_invA >= 10:
+            return length_invA / 100, "$\\mathrm{pm}^{-1}$"
+
+    # Handle direct metric units (distance)
+    if units in direct_unit_map:
+        # Everything to Å
+        if units in ["A", "Å", "angstrom", "Angstrom"]:
+            length_A = length_units
+        elif units in ["nm", "nanometer", "nanometre"]:
+            length_A = length_units * 10
+        elif units in ["um", "μm", "micrometer", "micrometre", "micron"]:
+            length_A = length_units * 1e4
+        elif units in ["mm", "millimeter", "millimetre"]:
+            length_A = length_units * 1e7
+        elif units in ["cm", "centimeter", "centimetre"]:
+            length_A = length_units * 1e8
+        elif units in ["m", "meter", "metre"]:
+            length_A = length_units * 1e10
+        else:
+            # fallback, should not happen due to keys in direct_unit_map
+            return length_units, units
+
+        if length_A <= 0.1:
+            return length_A * 100, "pm"
+        elif length_A < 10:
+            return length_A, "Å"
+        elif length_A < 1e4:
+            return length_A / 10, "nm"
+        elif length_A < 1e7:
+            return length_A / 1e4, "μm"
+        elif length_A < 1e10:
+            return length_A / 1e7, "mm"
+        else:
+            return length_A / 1e10, "m"
+
+    # fallback: unknown unit, return as is
+    return length_units, units
 
 
 def add_scalebar_to_ax(
@@ -336,6 +397,7 @@ def add_scalebar_to_ax(
 
     fontprops = FontProperties(size=fontsize, weight="bold" if bold else "normal")
 
+    label_top = loc[:3] == "low"
     bar = AnchoredSizeBar(
         ax.transData,
         length_px,
@@ -344,9 +406,10 @@ def add_scalebar_to_ax(
         pad=pad_px,
         color=color,
         frameon=False,
-        label_top=loc[:3] == "low",
+        label_top=label_top,
         size_vertical=int(width_px),
         fontproperties=fontprops,
+        sep=2 if label_top else int(round(0.3 * fontsize)),
     )
     ax.add_artist(bar)
 

--- a/tests/visualization/test_visualization_utils.py
+++ b/tests/visualization/test_visualization_utils.py
@@ -14,8 +14,8 @@ from quantem.core.visualization.visualization_utils import (
     add_scalebar_to_ax,
     array_to_rgba,
     bilinear_histogram_2d,
+    combine_arrays_to_rgba,
     estimate_scalebar_length,
-    list_of_arrays_to_rgba,
     turbo_black,
 )
 
@@ -85,14 +85,14 @@ class TestArrayToRGBA:
             array_to_rgba(sample_array, wrong_shape)
 
 
-class TestListOfArraysToRGBA:
-    def test_list_of_arrays_to_rgba(self, sample_arrays):
-        rgba = list_of_arrays_to_rgba(sample_arrays)
+class TestCombineArraysToRGBA:
+    def test_combine_arrays_to_rgba(self, sample_arrays):
+        rgba = combine_arrays_to_rgba(sample_arrays)
         assert rgba.shape == (*sample_arrays[0].shape, 4)
         assert np.all(rgba[..., 3] == 1)  # alpha channel should be 1
 
-    def test_list_of_arrays_to_rgba_with_chroma_boost(self, sample_arrays):
-        rgba = list_of_arrays_to_rgba(sample_arrays, chroma_boost=2.0)
+    def test_combine_arrays_to_rgba_with_chroma_boost(self, sample_arrays):
+        rgba = combine_arrays_to_rgba(sample_arrays, chroma_boost=2.0)
         assert rgba.shape == (*sample_arrays[0].shape, 4)
 
 


### PR DESCRIPTION
### What does this PR do?

This PR improves how `show_2d` accepts normalization and scalebar settings by introducing a small, autocomplete-friendly API, while keeping existing dict/string usage working.

Primarily it adds **`ShowParams`** with nested **`ShowParams.Norm`** and **`ShowParams.Scalebar`** dataclasses so users can discover fields via the editor instead of ad hoc dicts.


Tutorial notebook and examples: [quantem-tutorials PR #7](https://github.com/electronmicroscopy/quantem-tutorials/pull/7) (to be merged once this is)

### What should the reviewer(s) do?

- Run the tutorial notebook and suggest any changes to either the notebook itself or the API. 
- Review `show_params.py`, `visualization.py`, `custom_normalizations.py`, and `visualization_utils.py` for API clarity and backward compatibility.

- [x] This PR introduces a public-facing change (e.g., API, CLI input/output).
    - [x] For functional and algorithmic changes, tests are written or updated.
    - [x] Documentation (e.g., tutorials, examples, README) has been updated (via [quantem-tutorials#7](https://github.com/electronmicroscopy/quantem-tutorials/pull/7)).

### Reviewer checklist

- [ ] Tests pass and are appropriate for the changes
- [ ] Documentation and examples are sufficient and clear
- [x] Imported or adapted code has a compatible license
- [ ] The implementation matches the stated intent of the contribution
