### PR TITLE
fix for cropping

### DIFF
--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -23,7 +23,7 @@ class Dataset(AutoSerialize):
     Attributes (Properties):
         array (NDArray): The underlying n-dimensional NumPy array data.
         name (str): A descriptive name for the dataset.
-        origin (NDArray): The origin coordinates for each dimension (1D array).
+        origin (NDArray): The origin coordinates for each dimension (1D array) in calibrated units.
         sampling (NDArray): The sampling rate/spacing for each dimension (1D array).
         units (list[str]): Units for each dimension.
         signal_units (str): Units for the array values.
@@ -84,7 +84,7 @@ class Dataset(AutoSerialize):
         name: str | None
             The name of the Dataset.
         origin: NDArray | tuple | list | float | int | None
-            The origin of the Dataset.
+            The origin of the Dataset in calibrated units.
         sampling: NDArray | tuple | list | float | int | None
             The sampling of the Dataset.
         units: list[str] | tuple | list | None

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -875,22 +875,25 @@ class Dataset(AutoSerialize):
 
         # Compute which dimensions are kept
         kept_axes = [i for i, idx in enumerate(index) if not isinstance(idx, (int, np.integer))]
+        kept_axis_to_index = {axis: j for j, axis in enumerate(kept_axes)}
 
         # Slice/reduce metadata accordingly
-        new_origin = (
-            np.asarray(self.origin)[kept_axes] if np.ndim(self.origin) > 0 else self.origin
-        )
+        origin_array = np.asarray(self.origin, dtype=float)
+        sampling_array = np.asarray(self.sampling, dtype=float)
+        new_origin = origin_array[kept_axes].copy() if np.ndim(self.origin) > 0 else self.origin
         new_sampling = (
-            np.asarray(self.sampling)[kept_axes] if np.ndim(self.sampling) > 0 else self.sampling
+            sampling_array[kept_axes].copy() if np.ndim(self.sampling) > 0 else self.sampling
         )
         new_units = [self.units[i] for i in kept_axes] if len(self.units) > 0 else self.units
 
-        # Adjust sampling for slice steps (e.g. [::2] doubles spacing)
+        # Adjust origin/sampling for sliced axes.
         for i, idx in enumerate(index):
-            if isinstance(idx, slice) and idx.step not in (None, 1):
-                if i in kept_axes:
-                    j = kept_axes.index(i)
-                    new_sampling[j] *= idx.step
+            if isinstance(idx, slice) and i in kept_axis_to_index:
+                j = kept_axis_to_index[i]
+                normalized_start, _, normalized_step = idx.indices(self.shape[i])
+                new_origin[j] = new_origin[j] + normalized_start * sampling_array[i]
+                if normalized_step != 1:
+                    new_sampling[j] *= normalized_step
 
         out_ndim = array_view.ndim
 

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -511,22 +511,28 @@ class Dataset(AutoSerialize):
             raise ValueError("Length of crop_widths must match length of axes.")
 
         full_slices = []
+        new_origin = self.origin.astype(float).copy()
         crop_dict = dict(zip(axes, crop_widths))
-        for axis, _ in enumerate(self.shape):
+        for axis, axis_size in enumerate(self.shape):
             if axis in crop_dict:
                 before, after = crop_dict[axis]
                 start = before
                 stop = after if after != 0 else None
-                full_slices.append(slice(start, stop))
+                axis_slice = slice(start, stop)
+                normalized_start, _, _ = axis_slice.indices(axis_size)
+                full_slices.append(axis_slice)
+                new_origin[axis] = new_origin[axis] + normalized_start * self.sampling[axis]
             else:
                 full_slices.append(slice(None))
 
         if modify_in_place is False:
             dataset = self.copy()
             dataset.array = dataset.array[tuple(full_slices)]
+            dataset.origin = new_origin
             return dataset
 
         self.array = self.array[tuple(full_slices)]
+        self.origin = new_origin
         return None
 
     @overload

--- a/src/quantem/core/datastructures/dataset2d.py
+++ b/src/quantem/core/datastructures/dataset2d.py
@@ -40,7 +40,7 @@ class Dataset2d(Dataset):
         name : str
             A descriptive name for the dataset
         origin : NDArray | tuple | list | float | int
-            The origin coordinates for each dimension
+            The origin coordinates for each dimension in calibrated units
         sampling : NDArray | tuple | list | float | int
             The sampling rate/spacing for each dimension
         units : list[str] | tuple | list
@@ -102,9 +102,9 @@ class Dataset2d(Dataset):
         name : str | None, optional
             A descriptive name for the dataset. If None, defaults to "2D dataset"
         origin : NDArray | tuple | list | float | int | None, optional
-            The origin coordinates for each dimension. If None, defaults to zeros
+            The origin coordinates for each dimension in calibrated units. If None, defaults to zeros
         sampling : NDArray | tuple | list | float | int | None, optional
-            The sampling rate/spacing for each dimension. If None, defaults to ones
+            The sampling rate/spacing for each dimension in calibrated units. If None, defaults to ones
         units : list[str] | tuple | list | None, optional
             Units for each dimension. If None, defaults to ["pixels"] * 4
         signal_units : str, optional

--- a/src/quantem/core/datastructures/dataset3d.py
+++ b/src/quantem/core/datastructures/dataset3d.py
@@ -41,7 +41,7 @@ class Dataset3d(Dataset):
         name : str
             A descriptive name for the dataset
         origin : NDArray | tuple | list | float | int
-            The origin coordinates for each dimension
+            The origin coordinates for each dimension in calibrated units
         sampling : NDArray | tuple | list | float | int
             The sampling rate/spacing for each dimension
         units : list[str] | tuple | list
@@ -80,7 +80,7 @@ class Dataset3d(Dataset):
         name : str | None
             Dataset name. Default: "3D dataset"
         origin : NDArray | tuple | list | float | int | None
-            Origin for each dimension. Default: [0, 0, 0]
+            Origin for each dimension in calibrated units. Default: [0, 0, 0]
         sampling : NDArray | tuple | list | float | int | None
             Sampling for each dimension. Default: [1, 1, 1]
         units : list[str] | tuple | list | None
@@ -148,7 +148,7 @@ class Dataset3d(Dataset):
         fill_value : float
             Value to fill array with. Default: 0.0
         origin : NDArray | tuple | list | float | int | None
-            Origin for each dimension
+            Origin for each dimension in calibrated units.
         sampling : NDArray | tuple | list | float | int | None
             Sampling for each dimension
         units : list[str] | tuple | list | None
@@ -318,8 +318,7 @@ class Dataset3d(Dataset):
         ncols = min(ncols, n_frames)  # Don't create more columns than frames
         images = [self.array[i] for i in frame_idx]
         labels = [
-            f"Frame {i}" if title_prefix is None else f"{title_prefix} {i}"
-            for i in frame_idx
+            f"Frame {i}" if title_prefix is None else f"{title_prefix} {i}" for i in frame_idx
         ]
         # Pad last row to complete the grid (show_2d requires rectangular input)
         remainder = n_frames % ncols

--- a/src/quantem/core/datastructures/dataset4d.py
+++ b/src/quantem/core/datastructures/dataset4d.py
@@ -39,7 +39,7 @@ class Dataset4d(Dataset):
         name : str
             A descriptive name for the dataset
         origin : NDArray | tuple | list | float | int
-            The origin coordinates for each dimension
+            The origin coordinates for each dimension in calibrated units
         sampling : NDArray | tuple | list | float | int
             The sampling rate/spacing for each dimension
         units : list[str] | tuple | list

--- a/src/quantem/core/datastructures/dataset4dstem.py
+++ b/src/quantem/core/datastructures/dataset4dstem.py
@@ -59,7 +59,7 @@ class Dataset4dstem(Dataset4d):
         name : str
             A descriptive name for the dataset
         origin : NDArray | tuple | list | float | int
-            The origin coordinates for each dimension
+            The origin coordinates for each dimension in calibrated units
         sampling : NDArray | tuple | list | float | int
             The sampling rate/spacing for each dimension
         units : list[str] | tuple | list
@@ -133,7 +133,7 @@ class Dataset4dstem(Dataset4d):
         name : str | None, optional
             A descriptive name for the dataset. If None, defaults to "4D-STEM dataset"
         origin : NDArray | tuple | list | float | int | None, optional
-            The origin coordinates for each dimension. If None, defaults to zeros
+            The origin coordinates for each dimension in calibrated units. If None, defaults to zeros
         sampling : NDArray | tuple | list | float | int | None, optional
             The sampling rate/spacing for each dimension. If None, defaults to ones
         units : list[str] | tuple | list | None, optional

--- a/src/quantem/core/io/file_readers.py
+++ b/src/quantem/core/io/file_readers.py
@@ -38,7 +38,7 @@ def read_4dstem(
     name : str | None, optional
         A descriptive name for the dataset. If None, defaults to "4D-STEM dataset"
     origin : NDArray | tuple | list | float | int | None, optional
-        The origin coordinates for each dimension. If None, defaults to zeros
+        The origin coordinates for each dimension in calibrated units. If None, defaults to zeros
     sampling : NDArray | tuple | list | float | int | None, optional
         The sampling rate/spacing for each dimension. If None, defaults to ones
     units : list[str] | tuple | list | None, optional

--- a/src/quantem/diffractive_imaging/dataset_models.py
+++ b/src/quantem/diffractive_imaging/dataset_models.py
@@ -754,7 +754,7 @@ class PtychographyDatasetRaster(DatasetConstraints):
         name : str | None, optional
             A descriptive name for the dataset. If None, defaults to "4D-STEM dataset"
         origin : np.ndarray | tuple | list | float | int | None, optional
-            The origin coordinates for each dimension. If None, defaults to zeros
+            The origin coordinates for each dimension in calibrated units. If None, defaults to zeros
         sampling : np.ndarray | tuple | list | float | int | None, optional
             The sampling rate/spacing for each dimension. If None, defaults to ones
         units : list[str] | tuple | list | None, optional

--- a/tests/datastructures/test_dataset.py
+++ b/tests/datastructures/test_dataset.py
@@ -243,11 +243,14 @@ class TestDatasetMethods:
         cropped_dataset = sample_dataset_2d.crop(crop_widths=((1, 9), (1, 9)))
         # Check shape
         assert cropped_dataset.shape == (8, 8)  # Original (10, 10) - 1 from each side
+        assert np.array_equal(cropped_dataset.origin, np.array([1, 1]))
         # Check that the original dataset is unchanged
         assert sample_dataset_2d.shape == (10, 10)
+        assert np.array_equal(sample_dataset_2d.origin, np.array([0, 0]))
         # Test modify_in_place
         sample_dataset_2d.crop(crop_widths=((1, 9), (1, 9)), modify_in_place=True)
         assert sample_dataset_2d.shape == (8, 8)
+        assert np.array_equal(sample_dataset_2d.origin, np.array([1, 1]))
 
     def test_crop_4dstem_kspace(self):
         """Test cropping k-space axes of a 4D-STEM dataset."""
@@ -258,15 +261,31 @@ class TestDatasetMethods:
 
     def test_crop_4dstem_realspace_in_place(self):
         """Test in-place real-space crop of a 4D-STEM dataset."""
-        dset = Dataset.from_array(np.random.rand(16, 16, 32, 32))
+        dset = Dataset.from_array(
+            np.random.rand(16, 16, 32, 32),
+            origin=(10, 20, 30, 40),
+            sampling=(0.5, 0.25, 2, 3),
+        )
         dset.crop(crop_widths=((4, 12), (4, 12)), axes=(0, 1), modify_in_place=True)
         assert dset.shape == (8, 8, 32, 32)
+        assert np.array_equal(dset.origin, np.array([12, 21, 30, 40]))
 
     def test_crop_4dstem_stop_zero(self):
         """Test that stop=0 keeps all remaining elements."""
         dset = Dataset.from_array(np.random.rand(8, 8, 96, 96))
         cropped = dset.crop(crop_widths=((10, 0), (10, 0)), axes=(2, 3))
         assert cropped.shape == (8, 8, 86, 86)
+
+    def test_crop_single_axis_updates_origin_in_place(self):
+        """Test in-place single-axis crop updates origin."""
+        dset = Dataset.from_array(
+            np.random.rand(2048, 64),
+            origin=(5, 7),
+            sampling=(0.5, 2),
+        )
+        dset.crop(crop_widths=((80, 2000),), axes=0, modify_in_place=True)
+        assert dset.shape == (1920, 64)
+        assert np.array_equal(dset.origin, np.array([45, 7]))
 
     def test_bin(self, sample_dataset_2d):
         """Test bin method."""

--- a/tests/datastructures/test_dataset.py
+++ b/tests/datastructures/test_dataset.py
@@ -287,6 +287,39 @@ class TestDatasetMethods:
         assert dset.shape == (1920, 64)
         assert np.array_equal(dset.origin, np.array([45, 7]))
 
+    def test_getitem_slice_updates_origin_like_crop(self):
+        """Test slicing keeps origin aligned with crop semantics."""
+        dset = Dataset.from_array(
+            np.random.rand(16, 8),
+            origin=(10, 20),
+            sampling=(0.5, 2.0),
+            units=["nm", "nm"],
+        )
+
+        sliced = dset[4:12]
+        cropped = dset.crop(crop_widths=((4, 12),), axes=0)
+
+        assert sliced.shape == (8, 8)
+        assert np.array_equal(sliced.origin, np.array([12, 20]))
+        assert np.array_equal(sliced.origin, cropped.origin)
+        assert np.array_equal(sliced.sampling, cropped.sampling)
+
+    def test_getitem_slice_reduced_rank_updates_origin_and_sampling(self):
+        """Test slicing before integer indexing updates remaining metadata."""
+        dset = Dataset.from_array(
+            np.random.rand(10, 6, 4),
+            origin=(1.5, 10, -2),
+            sampling=(0.25, 2.0, 5.0),
+            units=["nm", "nm", "1/nm"],
+        )
+
+        sliced = dset[2:8:2, 3]
+
+        assert sliced.shape == (3, 4)
+        assert np.allclose(sliced.origin, np.array([2.0, -2.0]))
+        assert np.allclose(sliced.sampling, np.array([0.5, 5.0]))
+        assert sliced.units == ["nm", "1/nm"]
+
     def test_bin(self, sample_dataset_2d):
         """Test bin method."""
         # Bin by factor of 2


### PR DESCRIPTION
Previously when cropping a dataset, the origin wasn't shifted, which led to erroneous calibrations for spectroscopy data, for example.