### PR TITLE
Add optional hot pixel filtering in `read_4dstem`, default false for no unintended side effect 

### DIFF
--- a/src/quantem/core/io/file_readers.py
+++ b/src/quantem/core/io/file_readers.py
@@ -58,7 +58,7 @@ def read_4dstem(
 
     Examples
     --------
-    Load an Arina 4D-STEM master file with the default hot pixel filter:
+    Load a raw Arina 4D-STEM master file:
 
     >>> from quantem.core.io import read_4dstem
     >>> ds = read_4dstem(
@@ -68,12 +68,12 @@ def read_4dstem(
     >>> ds.array.shape
     (256, 256, 192, 192)
 
-    Skip the filter to inspect the raw detector output:
+    Enable the hot pixel filter to repair stuck detector pixels on load:
 
-    >>> ds_raw = read_4dstem(
+    >>> ds = read_4dstem(
     ...     '/path/to/gold_013_master.h5',
     ...     file_type='arina',
-    ...     hot_pixel_filter=False,
+    ...     hot_pixel_filter=True,
     ... )
     """
     if file_type is None:

--- a/src/quantem/core/io/file_readers.py
+++ b/src/quantem/core/io/file_readers.py
@@ -15,6 +15,7 @@ def read_4dstem(
     file_path: str | PathLike,
     file_type: str | None = None,
     dataset_index: int | None = None,
+    hot_pixel_filter: bool = False,
     **kwargs,
 ) -> Dataset4dstem:
     """
@@ -30,6 +31,11 @@ def read_4dstem(
     dataset_index: int, optional
         Index of the dataset to load if file contains multiple datasets.
         If None, automatically selects the first 4D dataset found.
+    hot_pixel_filter: bool, optional
+        If True, detect and replace hot detector pixels immediately after
+        loading using `quantem.core.utils.filter.filter_hot_pixels` with its
+        default parameters. For custom thresholds, call `filter_hot_pixels`
+        directly on the array.
     **kwargs: dict
         Additional keyword arguments to pass to the file reader.
 
@@ -49,6 +55,26 @@ def read_4dstem(
     Returns
     --------
     Dataset4dstem
+
+    Examples
+    --------
+    Load an Arina 4D-STEM master file with the default hot pixel filter:
+
+    >>> from quantem.core.io import read_4dstem
+    >>> ds = read_4dstem(
+    ...     '/path/to/gold_013_master.h5',
+    ...     file_type='arina',
+    ... )
+    >>> ds.array.shape
+    (256, 256, 192, 192)
+
+    Skip the filter to inspect the raw detector output:
+
+    >>> ds_raw = read_4dstem(
+    ...     '/path/to/gold_013_master.h5',
+    ...     file_type='arina',
+    ...     hot_pixel_filter=False,
+    ... )
     """
     if file_type is None:
         file_type = Path(file_path).suffix.lower().lstrip(".")
@@ -104,8 +130,14 @@ def read_4dstem(
         else ["pixels" if ax["units"] == "1" else ax["units"] for ax in imported_axes]
     )
 
+    array = imported_data["data"]
+    if hot_pixel_filter:
+        from quantem.core.utils.filter import filter_hot_pixels
+
+        array = filter_hot_pixels(array)
+
     dataset = Dataset4dstem.from_array(
-        array=imported_data["data"],
+        array=array,
         sampling=sampling,
         origin=origin,
         units=units,

--- a/tests/utils/test_filter.py
+++ b/tests/utils/test_filter.py
@@ -1,0 +1,24 @@
+"""Tests for `filter_hot_pixels`.
+
+A microscopist running 4D-STEM sees most detector pixels read out at low
+counts (~1-100), but a few are stuck near saturation (~60000) regardless of
+incident intensity. They must be removed before virtual imaging or dp_max
+analysis.
+"""
+
+import torch
+
+from quantem.core.utils.filter import filter_hot_pixels
+
+
+def test_filter_hot_pixels_replaces_stuck_detector_pixels_with_local_median():
+    """Stuck pixels should drop from 60000 back into the local bulk regime (<1000)."""
+    ds = torch.randint(1, 101, size=(64, 64, 32, 32), dtype=torch.int32)
+    # Assume these 3 places have hot pixels that we later want to remove
+    hot_coords = [(5, 7), (18, 24), (29, 3)]
+    for r, c in hot_coords:
+        ds[:, :, r, c] = 60000
+    filtered = filter_hot_pixels(ds.numpy())
+    dp_max = filtered.max(axis=(0, 1))
+    # no pixels should have value 101
+    assert dp_max.max() < 101, f"hot pixels still present, dp_max max={dp_max.max()}"

--- a/tests/utils/test_filter.py
+++ b/tests/utils/test_filter.py
@@ -1,18 +1,14 @@
-"""Tests for `filter_hot_pixels`.
-
-A microscopist running 4D-STEM sees most detector pixels read out at low
-counts (~1-100), but a few are stuck near saturation (~60000) regardless of
-incident intensity. They must be removed before virtual imaging or dp_max
-analysis.
-"""
-
 import torch
 
 from quantem.core.utils.filter import filter_hot_pixels
 
 
 def test_filter_hot_pixels_replaces_stuck_detector_pixels_with_local_median():
-    """Stuck pixels should drop from 60000 back into the local bulk regime (<1000)."""
+    """A microscopist running 4D-STEM sees most detector pixels read out at low
+    counts (~1-100), but a few are stuck near saturation (~60000) regardless
+    of incident intensity. After `filter_hot_pixels`, those stuck pixels
+    should drop back into the local bulk regime (<=100).
+    """
     ds = torch.randint(1, 101, size=(64, 64, 32, 32), dtype=torch.int32)
     # Assume these 3 places have hot pixels that we later want to remove
     hot_coords = [(5, 7), (18, 24), (29, 3)]


### PR DESCRIPTION
### What problem this PR addreseses

Closes https://github.com/electronmicroscopy/quantem/issues/221

Before

```
ds_raw = read_4dstem(PATH, file_type='arina')
show_2d(ds_raw.dp_mean.array, title='dp_mean (raw)', axsize=(8, 8))
```

<img width="528" height="537" alt="Screenshot 2026-05-06 at 7 01 29 PM" src="https://github.com/user-attachments/assets/47e9709c-0578-4eb4-a69a-792906bf7588" />

After

```
ds = read_4dstem(PATH, file_type='arina', hot_pixel_filter=True)
show_2d(ds.dp_mean.array, title='dp_mean (filtered)', axsize=(8, 8))
```

<img width="522" height="548" alt="Screenshot 2026-05-06 at 7 01 38 PM" src="https://github.com/user-attachments/assets/b5ee17df-5aa1-49a7-9cdc-d6c275321550" />


### What should the reviewer(s) do

Default `False` to avoid any intended mutation for loading data. 

I added a quick test for filtering.

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] For functional and algorithmic changes, tests are written or updated.
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.

