### PR TITLE
`Dataset4dstemTorch` - simple data class to containerize VRAM 4DSTEM data for streamlined 4DSTEM workflows

### DIFF
--- a/src/quantem/core/datastructures/__init__.py
+++ b/src/quantem/core/datastructures/__init__.py
@@ -2,6 +2,7 @@ from quantem.core.datastructures.dataset import Dataset as Dataset
 from quantem.core.datastructures.vector import Vector as Vector
 
 from quantem.core.datastructures.dataset4dstem import Dataset4dstem as Dataset4dstem
+from quantem.core.datastructures.dataset4dstem_torch import Dataset4dstemTorch as Dataset4dstemTorch
 from quantem.core.datastructures.dataset4d import Dataset4d as Dataset4d
 from quantem.core.datastructures.dataset3d import Dataset3d as Dataset3d
 from quantem.core.datastructures.dataset2d import Dataset2d as Dataset2d

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -11,11 +11,21 @@ class Dataset4dstemTorch:
     (``array``, ``name``, ``origin``, ``sampling``, ``units``,
     ``signal_units``).
 
-    Goal: keep 4D-STEM data on the GPU end-to-end and skip VRAM <-> RAM
-    round-trips. Each hop is expensive on multi-GB datasets and doubles
-    peak memory. Wrapping a cupy or torch GPU array here is effectively
-    free and holds the original VRAM allocation.
+    ``Dataset4dstem`` wraps a numpy array and lives in CPU RAM. Use it
+    when the raw data starts on the host (file readers that return numpy,
+    CPU-only analysis).
+
+    Use ``Dataset4dstemTorch`` instead when the raw data already lives on
+    the GPU - any CUDA pipeline producing torch / cupy arrays, live
+    streaming detector frames, GPU file readers. Wrapping the existing
+    GPU array is effectively free and the data stays in VRAM end-to-end.
+    Going through the CPU class instead forces a copy from GPU to CPU on
+    wrap and another copy from CPU back to GPU when the consumer
+    re-uploads, which is expensive on multi-GB datasets and doubles peak
+    memory.
     """
+
+    _token = object()
 
     def __init__(
         self,
@@ -25,7 +35,10 @@ class Dataset4dstemTorch:
         sampling: tuple[float, ...] | list[float] | None = None,
         units: list[str] | tuple[str, ...] | None = None,
         signal_units: str = "arb. units",
+        _token: object | None = None,
     ):
+        if _token is not self._token:
+            raise RuntimeError("Use Dataset4dstemTorch.from_array() to instantiate this class.")
         if not (isinstance(array, torch.Tensor) and array.ndim == 4):
             raise TypeError("Dataset4dstemTorch requires a 4D torch tensor")
         self.array = array
@@ -59,4 +72,5 @@ class Dataset4dstemTorch:
             sampling=sampling,
             units=units,
             signal_units=signal_units,
+            _token=cls._token,
         )

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -32,6 +32,7 @@ class Dataset4dstemTorch:
         sampling: tuple[float, ...] | list[float] | None = None,
         units: list[str] | tuple[str, ...] | None = None,
         signal_units: str = "arb. units",
+        metadata: dict | None = None,
         _token: object | None = None,
     ):
         """Initialize a torch-backed 4D-STEM dataset.
@@ -51,6 +52,10 @@ class Dataset4dstemTorch:
             Units for each dimension. If None, defaults to ["pixels"] * 4.
         signal_units : str, optional
             Units for the array values, by default "arb. units".
+        metadata : dict | None, optional
+            Mirror of ``Dataset4dstem.metadata``. Auto-populates
+            ``r_to_q_rotation_cw_deg`` and ``ellipticity`` keys with
+            ``None`` so consumers expecting them do not need a guard.
         _token : object | None, optional
             Token to prevent direct instantiation, by default None.
         """
@@ -76,6 +81,9 @@ class Dataset4dstemTorch:
         self.sampling = np.asarray(sampling if sampling is not None else (1, 1, 1, 1), dtype=float)
         self.units = list(units) if units is not None else ["pixels"] * 4
         self.signal_units = signal_units
+        self.metadata = dict(metadata) if metadata is not None else {}
+        for k in ("r_to_q_rotation_cw_deg", "ellipticity"):
+            self.metadata.setdefault(k, None)
 
     @classmethod
     def from_array(
@@ -86,8 +94,9 @@ class Dataset4dstemTorch:
         sampling: tuple[float, ...] | list[float] | None = None,
         units: list[str] | tuple[str, ...] | None = None,
         signal_units: str = "arb. units",
+        metadata: dict | None = None,
     ) -> Self:
-        """Create a new Dataset4dstemTorch from a torch tensor or dlpack-compatible array.
+        """Create a Dataset4dstemTorch from a torch tensor or dlpack-compatible array.
 
         torch tensors pass through. Cupy / jax / other GPU arrays exposing
         the dlpack protocol wrap zero-copy via ``torch.from_dlpack``.
@@ -96,8 +105,7 @@ class Dataset4dstemTorch:
         ----------
         array : object
             A 4D ``torch.Tensor`` or any object exposing the dlpack
-            protocol (e.g. ``cupy.ndarray``, ``jax.Array``). Non-tensor
-            inputs wrap zero-copy via ``torch.from_dlpack``.
+            protocol (e.g. ``cupy.ndarray``, ``jax.Array``).
         name : str | None, optional
             A descriptive name for the dataset. If None, defaults to
             "4D-STEM dataset (torch)".
@@ -110,6 +118,10 @@ class Dataset4dstemTorch:
             Units for each dimension. If None, defaults to ["pixels"] * 4.
         signal_units : str, optional
             Units for the array values, by default "arb. units".
+        metadata : dict | None, optional
+            Per-dataset metadata mirroring ``Dataset4dstem.metadata``.
+            Auto-populates ``r_to_q_rotation_cw_deg`` and ``ellipticity``
+            keys with ``None``.
 
         Returns
         -------
@@ -135,5 +147,6 @@ class Dataset4dstemTorch:
             sampling=sampling,
             units=units,
             signal_units=signal_units,
+            metadata=metadata,
             _token=cls._token,
         )

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -5,24 +5,15 @@ import torch
 
 
 class Dataset4dstemTorch:
-    """Minimal torch-backed 4D-STEM container.
+    """Torch-backed 4D-STEM container. GPU counterpart to ``Dataset4dstem``.
 
-    Holds a 4D ``torch.Tensor`` (any device) plus standard metadata fields
-    (``array``, ``name``, ``origin``, ``sampling``, ``units``,
-    ``signal_units``).
-
-    ``Dataset4dstem`` wraps a numpy array and lives in CPU RAM. Use it
-    when the raw data starts on the host (file readers that return numpy,
-    CPU-only analysis).
-
-    Use ``Dataset4dstemTorch`` instead when the raw data already lives on
-    the GPU - any CUDA pipeline producing torch / cupy arrays, live
-    streaming detector frames, GPU file readers. Wrapping the existing
-    GPU array is effectively free and the data stays in VRAM end-to-end.
-    Going through the CPU class instead forces a copy from GPU to CPU on
-    wrap and another copy from CPU back to GPU when the consumer
-    re-uploads, which is expensive on multi-GB datasets and doubles peak
-    memory.
+    Same metadata surface (``array``, ``name``, ``origin``, ``sampling``,
+    ``units``, ``signal_units``) but ``array`` is a 4D ``torch.Tensor``
+    on any device. Use when the raw data already lives on the GPU (CUDA
+    pipelines, live detector frames, GPU file readers) so it stays in
+    VRAM end-to-end. Wrapping with ``Dataset4dstem`` instead requires a
+    device-to-host transfer on wrap and a host-to-device transfer on
+    consume, doubling peak memory.
     """
 
     _token = object()

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -1,0 +1,62 @@
+from typing import Any, Self
+
+import numpy as np
+import torch
+
+
+class Dataset4dstemTorch:
+    """Minimal torch-backed 4D-STEM container.
+
+    Holds a 4D ``torch.Tensor`` (any device) plus standard metadata fields
+    (``array``, ``name``, ``origin``, ``sampling``, ``units``,
+    ``signal_units``).
+
+    Goal: keep 4D-STEM data on the GPU end-to-end and skip VRAM <-> RAM
+    round-trips. Each hop is expensive on multi-GB datasets and doubles
+    peak memory. Wrapping a cupy or torch GPU array here is effectively
+    free and holds the original VRAM allocation.
+    """
+
+    def __init__(
+        self,
+        array: torch.Tensor,
+        name: str = "4dstem (torch)",
+        origin: tuple[float, ...] | list[float] | None = None,
+        sampling: tuple[float, ...] | list[float] | None = None,
+        units: list[str] | tuple[str, ...] | None = None,
+        signal_units: str = "arb. units",
+    ):
+        if not (isinstance(array, torch.Tensor) and array.ndim == 4):
+            raise TypeError("Dataset4dstemTorch requires a 4D torch tensor")
+        self.array = array
+        self.name = name
+        self.origin = np.asarray(origin if origin is not None else (0, 0, 0, 0), dtype=float)
+        self.sampling = np.asarray(sampling if sampling is not None else (1, 1, 1, 1), dtype=float)
+        self.units = list(units) if units is not None else ["pixels"] * 4
+        self.signal_units = signal_units
+
+    @classmethod
+    def from_array(
+        cls,
+        array: Any,
+        name: str | None = None,
+        origin: tuple[float, ...] | list[float] | None = None,
+        sampling: tuple[float, ...] | list[float] | None = None,
+        units: list[str] | tuple[str, ...] | None = None,
+        signal_units: str = "arb. units",
+    ) -> Self:
+        """Create from a torch tensor or any dlpack-compatible array.
+
+        torch tensors pass through. cupy / jax / other GPU arrays wrap
+        zero-copy via ``torch.from_dlpack``.
+        """
+        if not isinstance(array, torch.Tensor):
+            array = torch.from_dlpack(array)
+        return cls(
+            array=array,
+            name=name if name is not None else "4dstem (torch)",
+            origin=origin,
+            sampling=sampling,
+            units=units,
+            signal_units=signal_units,
+        )

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -2,9 +2,9 @@ from typing import Self
 
 import numpy as np
 import torch
+from quantem.core.io.serialize import AutoSerialize
 
-
-class Dataset4dstemTorch:
+class Dataset4dstemTorch(AutoSerialize):
     """A torch-backed 4D-STEM dataset class. GPU counterpart to ``Dataset4dstem``.
 
     Same metadata surface as ``Dataset4dstem`` (``array``, ``name``,

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -5,15 +5,21 @@ import torch
 
 
 class Dataset4dstemTorch:
-    """Torch-backed 4D-STEM container. GPU counterpart to ``Dataset4dstem``.
+    """A torch-backed 4D-STEM dataset class. GPU counterpart to ``Dataset4dstem``.
 
-    Same metadata surface (``array``, ``name``, ``origin``, ``sampling``,
-    ``units``, ``signal_units``) but ``array`` is a 4D ``torch.Tensor``
-    on any device. Use when the raw data already lives on the GPU (CUDA
-    pipelines, live detector frames, GPU file readers) so it stays in
-    VRAM end-to-end. Wrapping with ``Dataset4dstem`` instead requires a
-    device-to-host transfer on wrap and a host-to-device transfer on
-    consume, doubling peak memory.
+    Same metadata surface as ``Dataset4dstem`` (``array``, ``name``,
+    ``origin``, ``sampling``, ``units``, ``signal_units``) but ``array``
+    is a 4D ``torch.Tensor`` on any device instead of a numpy array. Use
+    when the raw data already lives on the GPU (CUDA pipelines, live
+    detector frames, GPU file readers) so it stays in VRAM end-to-end.
+    Wrapping with ``Dataset4dstem`` instead requires a device-to-host
+    transfer on wrap and a host-to-device transfer on consume, doubling
+    peak memory.
+
+    Notes
+    -----
+    Construction is gated by a token: use ``Dataset4dstemTorch.from_array``
+    rather than calling the constructor directly.
     """
 
     _token = object()
@@ -21,17 +27,49 @@ class Dataset4dstemTorch:
     def __init__(
         self,
         array: torch.Tensor,
-        name: str = "4dstem (torch)",
+        name: str = "4D-STEM dataset (torch)",
         origin: tuple[float, ...] | list[float] | None = None,
         sampling: tuple[float, ...] | list[float] | None = None,
         units: list[str] | tuple[str, ...] | None = None,
         signal_units: str = "arb. units",
         _token: object | None = None,
     ):
+        """Initialize a torch-backed 4D-STEM dataset.
+
+        Parameters
+        ----------
+        array : torch.Tensor
+            The underlying 4D tensor data on any device.
+        name : str, optional
+            A descriptive name for the dataset, by default "4D-STEM dataset (torch)".
+        origin : tuple[float, ...] | list[float] | None, optional
+            The origin coordinates for each dimension in calibrated units.
+            If None, defaults to zeros.
+        sampling : tuple[float, ...] | list[float] | None, optional
+            The sampling rate/spacing for each dimension. If None, defaults to ones.
+        units : list[str] | tuple[str, ...] | None, optional
+            Units for each dimension. If None, defaults to ["pixels"] * 4.
+        signal_units : str, optional
+            Units for the array values, by default "arb. units".
+        _token : object | None, optional
+            Token to prevent direct instantiation, by default None.
+        """
         if _token is not self._token:
-            raise RuntimeError("Use Dataset4dstemTorch.from_array() to instantiate this class.")
-        if not (isinstance(array, torch.Tensor) and array.ndim == 4):
-            raise TypeError("Dataset4dstemTorch requires a 4D torch tensor")
+            raise RuntimeError(
+                "Use Dataset4dstemTorch.from_array() to instantiate this class."
+            )
+        if not isinstance(array, torch.Tensor):
+            raise TypeError(
+                f"Dataset4dstemTorch requires a torch.Tensor, got {type(array).__name__}. "
+                f"Convert with torch.from_dlpack(array) for cupy / jax arrays, or use "
+                f"Dataset4dstem for numpy."
+            )
+        if array.ndim != 4:
+            raise ValueError(
+                f"Dataset4dstemTorch requires a 4D tensor (scan_rows, scan_cols, "
+                f"det_rows, det_cols), got shape {tuple(array.shape)} "
+                f"({array.ndim}D)."
+            )
         self.array = array
         self.name = name
         self.origin = np.asarray(origin if origin is not None else (0, 0, 0, 0), dtype=float)
@@ -49,16 +87,49 @@ class Dataset4dstemTorch:
         units: list[str] | tuple[str, ...] | None = None,
         signal_units: str = "arb. units",
     ) -> Self:
-        """Create from a torch tensor or any dlpack-compatible array.
+        """Create a new Dataset4dstemTorch from a torch tensor or dlpack-compatible array.
 
-        torch tensors pass through. cupy / jax / other GPU arrays wrap
-        zero-copy via ``torch.from_dlpack``.
+        torch tensors pass through. Cupy / jax / other GPU arrays exposing
+        the dlpack protocol wrap zero-copy via ``torch.from_dlpack``.
+
+        Parameters
+        ----------
+        array : Any
+            A 4D ``torch.Tensor`` or any object exposing the dlpack
+            protocol (e.g. ``cupy.ndarray``).
+        name : str | None, optional
+            A descriptive name for the dataset. If None, defaults to
+            "4D-STEM dataset (torch)".
+        origin : tuple[float, ...] | list[float] | None, optional
+            The origin coordinates for each dimension in calibrated units.
+            If None, defaults to zeros.
+        sampling : tuple[float, ...] | list[float] | None, optional
+            The sampling rate/spacing for each dimension. If None, defaults to ones.
+        units : list[str] | tuple[str, ...] | None, optional
+            Units for each dimension. If None, defaults to ["pixels"] * 4.
+        signal_units : str, optional
+            Units for the array values, by default "arb. units".
+
+        Returns
+        -------
+        Dataset4dstemTorch
+            A new Dataset4dstemTorch instance wrapping ``array`` in place.
+
+        Examples
+        --------
+        >>> import torch
+        >>> ds = Dataset4dstemTorch.from_array(torch.rand(64, 64, 128, 128, device="cuda"))
+        >>> ds.array.device
+        device(type='cuda', index=0)
+
+        >>> import cupy as cp
+        >>> ds = Dataset4dstemTorch.from_array(cp.zeros((64, 64, 128, 128), dtype=cp.uint16))
         """
         if not isinstance(array, torch.Tensor):
             array = torch.from_dlpack(array)
         return cls(
             array=array,
-            name=name if name is not None else "4dstem (torch)",
+            name=name if name is not None else "4D-STEM dataset (torch)",
             origin=origin,
             sampling=sampling,
             units=units,

--- a/src/quantem/core/datastructures/dataset4dstem_torch.py
+++ b/src/quantem/core/datastructures/dataset4dstem_torch.py
@@ -1,4 +1,4 @@
-from typing import Any, Self
+from typing import Self
 
 import numpy as np
 import torch
@@ -80,7 +80,7 @@ class Dataset4dstemTorch:
     @classmethod
     def from_array(
         cls,
-        array: Any,
+        array: object,
         name: str | None = None,
         origin: tuple[float, ...] | list[float] | None = None,
         sampling: tuple[float, ...] | list[float] | None = None,
@@ -94,9 +94,10 @@ class Dataset4dstemTorch:
 
         Parameters
         ----------
-        array : Any
+        array : object
             A 4D ``torch.Tensor`` or any object exposing the dlpack
-            protocol (e.g. ``cupy.ndarray``).
+            protocol (e.g. ``cupy.ndarray``, ``jax.Array``). Non-tensor
+            inputs wrap zero-copy via ``torch.from_dlpack``.
         name : str | None, optional
             A descriptive name for the dataset. If None, defaults to
             "4D-STEM dataset (torch)".

--- a/tests/datastructures/test_dataset4dstem_torch.py
+++ b/tests/datastructures/test_dataset4dstem_torch.py
@@ -15,24 +15,20 @@ def sample_4d_tensor():
 
 
 class TestDataset4dstemTorch:
-    def test_construction(self, sample_4d_tensor):
-        ds = Dataset4dstemTorch(sample_4d_tensor)
-        assert ds.array is sample_4d_tensor  # zero-copy wrap
-        assert ds.name == "4dstem (torch)"
-        assert ds.units == ["pixels"] * 4
-        assert ds.signal_units == "arb. units"
-        np.testing.assert_array_equal(ds.sampling, np.ones(4))
-        np.testing.assert_array_equal(ds.origin, np.zeros(4))
-
-    def test_metadata_overrides(self, sample_4d_tensor):
-        ds = Dataset4dstemTorch(
+    def test_from_array(self, sample_4d_tensor):
+        ds = Dataset4dstemTorch.from_array(
             sample_4d_tensor,
             name="lamella",
             sampling=(0.5, 0.5, 0.46, 0.46),
             units=["A", "A", "mrad", "mrad"],
             signal_units="counts",
         )
+        assert ds.array is sample_4d_tensor
         assert ds.name == "lamella"
         assert ds.units == ["A", "A", "mrad", "mrad"]
         assert ds.signal_units == "counts"
         np.testing.assert_allclose(ds.sampling, [0.5, 0.5, 0.46, 0.46])
+
+    def test_direct_init_blocked(self, sample_4d_tensor):
+        with pytest.raises(RuntimeError, match="from_array"):
+            Dataset4dstemTorch(sample_4d_tensor)

--- a/tests/datastructures/test_dataset4dstem_torch.py
+++ b/tests/datastructures/test_dataset4dstem_torch.py
@@ -32,3 +32,15 @@ class TestDataset4dstemTorch:
     def test_direct_init_blocked(self, sample_4d_tensor):
         with pytest.raises(RuntimeError, match="from_array"):
             Dataset4dstemTorch(sample_4d_tensor)
+
+    def test_metadata_defaults_and_override(self, sample_4d_tensor):
+        ds = Dataset4dstemTorch.from_array(sample_4d_tensor)
+        assert ds.metadata == {"r_to_q_rotation_cw_deg": None, "ellipticity": None}
+
+        ds = Dataset4dstemTorch.from_array(
+            sample_4d_tensor,
+            metadata={"r_to_q_rotation_cw_deg": 12.5, "voltage_kV": 200},
+        )
+        assert ds.metadata["r_to_q_rotation_cw_deg"] == 12.5
+        assert ds.metadata["voltage_kV"] == 200
+        assert ds.metadata["ellipticity"] is None  # auto-populated

--- a/tests/datastructures/test_dataset4dstem_torch.py
+++ b/tests/datastructures/test_dataset4dstem_torch.py
@@ -1,0 +1,38 @@
+"""
+Tests for the Dataset4dstemTorch class in quantem.core.datastructures.dataset4dstem_torch
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from quantem.core.datastructures import Dataset4dstemTorch
+
+
+@pytest.fixture
+def sample_4d_tensor():
+    return torch.rand(5, 5, 10, 10)
+
+
+class TestDataset4dstemTorch:
+    def test_construction(self, sample_4d_tensor):
+        ds = Dataset4dstemTorch(sample_4d_tensor)
+        assert ds.array is sample_4d_tensor  # zero-copy wrap
+        assert ds.name == "4dstem (torch)"
+        assert ds.units == ["pixels"] * 4
+        assert ds.signal_units == "arb. units"
+        np.testing.assert_array_equal(ds.sampling, np.ones(4))
+        np.testing.assert_array_equal(ds.origin, np.zeros(4))
+
+    def test_metadata_overrides(self, sample_4d_tensor):
+        ds = Dataset4dstemTorch(
+            sample_4d_tensor,
+            name="lamella",
+            sampling=(0.5, 0.5, 0.46, 0.46),
+            units=["A", "A", "mrad", "mrad"],
+            signal_units="counts",
+        )
+        assert ds.name == "lamella"
+        assert ds.units == ["A", "A", "mrad", "mrad"]
+        assert ds.signal_units == "counts"
+        np.testing.assert_allclose(ds.sampling, [0.5, 0.5, 0.46, 0.46])


### PR DESCRIPTION
### What problem this PR addreseses

Closes https://github.com/electronmicroscopy/quantem/issues/222

Simple solution to use native `quantem` datastructure for all downstream 4DSTEM workflows:

Effect: avoid VRAM-RAM-VRAM copy, less memory footprint, faster loading for widgets and vectorization operations.

Demo:

<img width="800" height="601" alt="sepen_gif_20260514_190238" src="https://github.com/user-attachments/assets/51156055-7a52-4046-8c1e-abd4afb92255" />

### What should the reviewer(s) do

No side effect on any of the existing codebase. Made this class dead simple - add more features as needed. 

It is primarily used by my code and will later extend to 5DSTEM (tilt/time).