### PR TITLE
`dataset4dstem` support torch array while maintaining backward compatibility

### DIFF
--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any, Literal, Optional, Self, Union, overload
 
 import numpy as np
+import torch
 from numpy.typing import DTypeLike, NDArray
 
 from quantem.core.io.serialize import AutoSerialize
@@ -38,24 +39,39 @@ class Dataset(AutoSerialize):
 
     def __init__(
         self,
-        array: Any,  # Input can be array-like
-        name: str,
-        origin: NDArray | tuple | list | float | int,
-        sampling: NDArray | tuple | list | float | int,
-        units: list[str] | tuple | list,
+        array: NDArray | None = None,
+        tensor: torch.Tensor | None = None,
+        name: str = "",
+        origin: NDArray | tuple | list | float | int | None = None,
+        sampling: NDArray | tuple | list | float | int | None = None,
+        units: list[str] | tuple | list | None = None,
         signal_units: str = "arb. units",
         metadata: Optional[dict] = None,
         _token: object | None = None,
     ):
         if _token is not self._token:
-            raise RuntimeError("Use Dataset.from_array() to instantiate this class.")
-        super().__init__()
-        arr = ensure_valid_array(array)
-        if not isinstance(arr, np.ndarray):
-            raise TypeError(
-                "Dataset requires a NumPy array (CuPy is not supported on this branch)."
+            raise RuntimeError(
+                "Use Dataset.from_array() or Dataset.from_tensor() to instantiate this class."
             )
-        self._array = arr
+        super().__init__()
+        # Dual-slot storage: exactly one of (_array, _tensor) is set.
+        if array is None and tensor is None:
+            raise ValueError("Provide either `array` (numpy) or `tensor` (torch).")
+        if array is not None and tensor is not None:
+            raise ValueError("Provide only one of `array` or `tensor`, not both.")
+        if array is not None:
+            arr = ensure_valid_array(array)
+            if not isinstance(arr, np.ndarray):
+                raise TypeError(f"Dataset.array must be numpy.ndarray, got {type(arr).__name__}.")
+            self._array = arr
+            self._tensor = None
+        else:
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(f"Dataset.tensor must be torch.Tensor, got {type(tensor).__name__}.")
+            self._array = None
+            self._tensor = tensor
+        # Lazy cache: derived numpy from tensor, materialized only on first .array access.
+        self._cached_numpy: np.ndarray | None = None
         self.name = name
         self.origin = origin
         self.sampling = sampling
@@ -123,18 +139,34 @@ class Dataset(AutoSerialize):
     # --- Properties ---
     @property
     def array(self) -> NDArray:
-        """The underlying n-dimensional NumPy array data."""
-        return self._array
+        """The data as a numpy array.
+
+        For tensor-backed datasets, returns a CACHED read-only CPU copy derived
+        from ``self.tensor`` (first access pays GPU->CPU transfer, subsequent
+        accesses are free). Torch-aware consumers should prefer ``.tensor``.
+        """
+        if self._array is not None:
+            return self._array
+        if self._cached_numpy is None:
+            self._cached_numpy = self._tensor.detach().cpu().numpy()
+            self._cached_numpy.flags.writeable = False
+        return self._cached_numpy
 
     @array.setter
     def array(self, value: NDArray) -> None:
-        arr = ensure_valid_array(value, ndim=self.ndim)  # want to allow changing dtype
+        arr = ensure_valid_array(value, ndim=self.ndim)
         if not isinstance(arr, np.ndarray):
-            raise TypeError(
-                "Dataset requires a NumPy array (CuPy is not supported on this branch)."
-            )
+            raise TypeError(f"Dataset.array must be numpy.ndarray, got {type(arr).__name__}.")
         self._array = arr
-        # self._array = ensure_valid_array(value, dtype=self.dtype, ndim=self.ndim)
+
+    @property
+    def tensor(self) -> torch.Tensor:
+        """Torch tensor backing the data. AttributeError if numpy-backed."""
+        if self._tensor is None:
+            raise AttributeError(
+                f"Dataset '{self.name}' is numpy-backed; use Dataset.from_tensor() at construction."
+            )
+        return self._tensor
 
     @property
     def metadata(self) -> dict:
@@ -191,26 +223,42 @@ class Dataset(AutoSerialize):
     # --- Derived Properties ---
     @property
     def shape(self) -> tuple[int, ...]:
-        return self.array.shape
+        # Direct slot access — never triggers .array derive (which would force
+        # a full GPU->CPU copy on tensor-backed datasets).
+        return tuple((self._array if self._array is not None else self._tensor).shape)
 
     @property
     def ndim(self) -> int:
-        return self.array.ndim
+        return (self._array if self._array is not None else self._tensor).ndim
 
     @property
     def dtype(self) -> DTypeLike:
-        return self.array.dtype
+        return (self._array if self._array is not None else self._tensor).dtype
 
     @property
     def device(self) -> str:
-        """
-        Outputting a string is likely temporary -- once we have our use cases we can
-        figure out a more permanent device solution that enables easier translation between
-        numpy <-> torch <-> numpy, etc.
-
-        For NumPy-only datasets, this is always "cpu".
-        """
+        """``"cpu"`` for numpy-backed; torch device string for tensor-backed."""
+        if self._tensor is not None:
+            return str(self._tensor.device)
         return "cpu"
+
+    def numpy(self) -> NDArray:
+        """Return the data as a numpy array (mirrors ``torch.Tensor.numpy()``).
+
+        Equivalent to ``self.array`` — both return numpy. For tensor-backed
+        datasets, first call materializes a cached read-only CPU copy.
+        """
+        return self.array
+
+    def to(self, device) -> Self:
+        """Move the underlying tensor to ``device``. Raises if numpy-backed."""
+        if self._tensor is None:
+            raise AttributeError(
+                f"Cannot .to({device!r}) on numpy-backed Dataset '{self.name}'."
+            )
+        self._tensor = self._tensor.to(device)
+        self._cached_numpy = None  # invalidate stale derived numpy
+        return self
 
     # --- Summaries ---
     def __repr__(self) -> str:

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -70,8 +70,6 @@ class Dataset(AutoSerialize):
                 raise TypeError(f"Dataset.tensor must be torch.Tensor, got {type(tensor).__name__}.")
             self._array = None
             self._tensor = tensor
-        # Lazy cache: derived numpy from tensor, materialized only on first .array access.
-        self._cached_numpy: np.ndarray | None = None
         self.name = name
         self.origin = origin
         self.sampling = sampling
@@ -138,19 +136,13 @@ class Dataset(AutoSerialize):
 
     # --- Properties ---
     @property
-    def array(self) -> NDArray:
+    def array(self) -> NDArray | None:
         """The underlying n-dimensional NumPy array data.
 
-        For tensor-backed datasets, returns a CACHED read-only CPU copy derived
-        from ``self.tensor`` (first access pays GPU->CPU transfer, subsequent
-        accesses are free). Torch-aware consumers should prefer ``.tensor``.
+        Returns ``None`` for tensor-backed datasets — use ``.tensor`` for the
+        torch tensor, or ``.numpy()`` to materialize a numpy copy explicitly.
         """
-        if self._array is not None:
-            return self._array
-        if self._cached_numpy is None:
-            self._cached_numpy = self._tensor.detach().cpu().numpy()
-            self._cached_numpy.flags.writeable = False
-        return self._cached_numpy
+        return self._array
 
     @array.setter
     def array(self, value: NDArray) -> None:
@@ -245,10 +237,12 @@ class Dataset(AutoSerialize):
     def numpy(self) -> NDArray:
         """Return the data as a numpy array (mirrors ``torch.Tensor.numpy()``).
 
-        Equivalent to ``self.array`` — both return numpy. For tensor-backed
-        datasets, first call materializes a cached read-only CPU copy.
+        For numpy-backed datasets, returns ``self.array`` directly. For
+        tensor-backed datasets, materializes a CPU copy via ``.detach().cpu().numpy()``.
         """
-        return self.array
+        if self._array is not None:
+            return self._array
+        return self._tensor.detach().cpu().numpy()
 
     def to(self, device) -> Self:
         """Move the underlying tensor to ``device``. Raises if numpy-backed."""
@@ -257,7 +251,6 @@ class Dataset(AutoSerialize):
                 f"Cannot .to({device!r}) on numpy-backed Dataset '{self.name}'."
             )
         self._tensor = self._tensor.to(device)
-        self._cached_numpy = None  # invalidate stale derived numpy
         return self
 
     # --- Summaries ---

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -55,6 +55,7 @@ class Dataset(AutoSerialize):
             )
         super().__init__()
         # Dual-slot storage: exactly one of (_array, _tensor) is set.
+        # TODO: remove dual-init guards once torch transition is complete.
         if array is None and tensor is None:
             raise ValueError("Provide either `array` (numpy) or `tensor` (torch).")
         if array is not None and tensor is not None:
@@ -229,37 +230,49 @@ class Dataset(AutoSerialize):
         return (array if array is not None else self._tensor).ndim
 
     @property
-    def dtype(self) -> DTypeLike:
+    def dtype(self) -> DTypeLike | torch.dtype:
         array = getattr(self, "_array", None)
         return (array if array is not None else self._tensor).dtype
 
     @property
     def device(self) -> str:
-        """``"cpu"`` for numpy-backed; torch device string for tensor-backed."""
-        tensor = getattr(self, "_tensor", None)
-        if tensor is not None:
-            return str(tensor.device)
-        return "cpu"
+        """Device string for the underlying storage. numpy 2.x ndarray and torch.Tensor
+        both expose ``.device`` (array-API convention), so this is uniform.
+        """
+        array = getattr(self, "_array", None)
+        return str((array if array is not None else self._tensor).device)
 
     def numpy(self) -> NDArray:
         """Return the data as a numpy array (mirrors ``torch.Tensor.numpy()``).
 
         For numpy-backed datasets, returns ``self.array`` directly. For
-        tensor-backed datasets, materializes a CPU copy via ``.detach().cpu().numpy()``.
+        tensor-backed datasets, materializes a read-only CPU copy via
+        ``.detach().cpu().numpy()``. ``flags.writeable=False`` so accidental
+        in-place writes raise instead of silently being lost (the copy is not
+        the tensor).
         """
         array = getattr(self, "_array", None)
         if array is not None:
             return array
-        return self._tensor.detach().cpu().numpy()
+        arr = self._tensor.detach().cpu().numpy()
+        arr.flags.writeable = False
+        return arr
 
     def to(self, device) -> Self:
-        """Move the underlying tensor to ``device``. Raises if numpy-backed."""
+        """Move the underlying tensor to ``device``. Raises if numpy-backed.
+
+        ``device`` is normalized via :func:`quantem.core.config.validate_device`
+        so values like ``"cuda"``, ``0``, ``"cuda:0"``, ``torch.device("cuda:0")``
+        all resolve to the same canonical device.
+        """
+        from quantem.core import config
         tensor = getattr(self, "_tensor", None)
         if tensor is None:
             raise AttributeError(
                 f"Cannot .to({device!r}) on numpy-backed Dataset '{self.name}'."
             )
-        self._tensor = tensor.to(device)
+        dev, _ = config.validate_device(device)
+        self._tensor = tensor.to(dev)
         return self
 
     # --- Summaries ---

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -139,7 +139,7 @@ class Dataset(AutoSerialize):
     def array(self) -> NDArray | None:
         """The underlying n-dimensional NumPy array data.
 
-        Returns ``None`` for tensor-backed datasets — use ``.tensor`` for the
+        Returns ``None`` for tensor-backed datasets. Use ``.tensor`` for the
         torch tensor, or ``.numpy()`` to materialize a numpy copy explicitly.
         """
         return self._array
@@ -215,7 +215,7 @@ class Dataset(AutoSerialize):
     # --- Derived Properties ---
     @property
     def shape(self) -> tuple[int, ...]:
-        # Direct slot access — never triggers .array derive (which would force
+        # Direct slot access (never triggers .array derive, which would force
         # a full GPU->CPU copy on tensor-backed datasets).
         return tuple((self._array if self._array is not None else self._tensor).shape)
 

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -139,7 +139,7 @@ class Dataset(AutoSerialize):
     # --- Properties ---
     @property
     def array(self) -> NDArray:
-        """The data as a numpy array.
+        """The underlying n-dimensional NumPy array data.
 
         For tensor-backed datasets, returns a CACHED read-only CPU copy derived
         from ``self.tensor`` (first access pays GPU->CPU transfer, subsequent

--- a/src/quantem/core/datastructures/dataset.py
+++ b/src/quantem/core/datastructures/dataset.py
@@ -142,7 +142,7 @@ class Dataset(AutoSerialize):
         Returns ``None`` for tensor-backed datasets. Use ``.tensor`` for the
         torch tensor, or ``.numpy()`` to materialize a numpy copy explicitly.
         """
-        return self._array
+        return getattr(self, "_array", None)
 
     @array.setter
     def array(self, value: NDArray) -> None:
@@ -154,11 +154,13 @@ class Dataset(AutoSerialize):
     @property
     def tensor(self) -> torch.Tensor:
         """Torch tensor backing the data. AttributeError if numpy-backed."""
-        if self._tensor is None:
+        # getattr handles AutoSerialize-restored instances (no __init__ run).
+        tensor = getattr(self, "_tensor", None)
+        if tensor is None:
             raise AttributeError(
                 f"Dataset '{self.name}' is numpy-backed; use Dataset.from_tensor() at construction."
             )
-        return self._tensor
+        return tensor
 
     @property
     def metadata(self) -> dict:
@@ -216,22 +218,27 @@ class Dataset(AutoSerialize):
     @property
     def shape(self) -> tuple[int, ...]:
         # Direct slot access (never triggers .array derive, which would force
-        # a full GPU->CPU copy on tensor-backed datasets).
-        return tuple((self._array if self._array is not None else self._tensor).shape)
+        # a full GPU->CPU copy on tensor-backed datasets). getattr handles
+        # AutoSerialize-restored instances (no __init__ run).
+        array = getattr(self, "_array", None)
+        return tuple((array if array is not None else self._tensor).shape)
 
     @property
     def ndim(self) -> int:
-        return (self._array if self._array is not None else self._tensor).ndim
+        array = getattr(self, "_array", None)
+        return (array if array is not None else self._tensor).ndim
 
     @property
     def dtype(self) -> DTypeLike:
-        return (self._array if self._array is not None else self._tensor).dtype
+        array = getattr(self, "_array", None)
+        return (array if array is not None else self._tensor).dtype
 
     @property
     def device(self) -> str:
         """``"cpu"`` for numpy-backed; torch device string for tensor-backed."""
-        if self._tensor is not None:
-            return str(self._tensor.device)
+        tensor = getattr(self, "_tensor", None)
+        if tensor is not None:
+            return str(tensor.device)
         return "cpu"
 
     def numpy(self) -> NDArray:
@@ -240,17 +247,19 @@ class Dataset(AutoSerialize):
         For numpy-backed datasets, returns ``self.array`` directly. For
         tensor-backed datasets, materializes a CPU copy via ``.detach().cpu().numpy()``.
         """
-        if self._array is not None:
-            return self._array
+        array = getattr(self, "_array", None)
+        if array is not None:
+            return array
         return self._tensor.detach().cpu().numpy()
 
     def to(self, device) -> Self:
         """Move the underlying tensor to ``device``. Raises if numpy-backed."""
-        if self._tensor is None:
+        tensor = getattr(self, "_tensor", None)
+        if tensor is None:
             raise AttributeError(
                 f"Cannot .to({device!r}) on numpy-backed Dataset '{self.name}'."
             )
-        self._tensor = self._tensor.to(device)
+        self._tensor = tensor.to(device)
         return self
 
     # --- Summaries ---

--- a/src/quantem/core/datastructures/dataset4d.py
+++ b/src/quantem/core/datastructures/dataset4d.py
@@ -1,6 +1,7 @@
 from typing import Any, Self, Union
 
 import numpy as np
+import torch
 from numpy.typing import NDArray
 
 from quantem.core.datastructures.dataset import Dataset
@@ -21,36 +22,20 @@ class Dataset4d(Dataset):
 
     def __init__(
         self,
-        array: NDArray | Any,
-        name: str,
-        origin: NDArray | tuple | list | float | int,
-        sampling: NDArray | tuple | list | float | int,
-        units: list[str] | tuple | list,
+        array: NDArray | None = None,
+        tensor: torch.Tensor | None = None,
+        name: str = "",
+        origin: NDArray | tuple | list | float | int | None = None,
+        sampling: NDArray | tuple | list | float | int | None = None,
+        units: list[str] | tuple | list | None = None,
         signal_units: str = "arb. units",
         metadata: dict = {},
         _token: object | None = None,
     ):
-        """Initialize a 4D dataset.
-
-        Parameters
-        ----------
-        array : NDArray | Any
-            The underlying 3D array data
-        name : str
-            A descriptive name for the dataset
-        origin : NDArray | tuple | list | float | int
-            The origin coordinates for each dimension in calibrated units
-        sampling : NDArray | tuple | list | float | int
-            The sampling rate/spacing for each dimension
-        units : list[str] | tuple | list
-            Units for each dimension
-        signal_units : str, optional
-            Units for the array values, by default "arb. units"
-        _token : object | None, optional
-            Token to prevent direct instantiation, by default None
-        """
+        """Initialize a 4D dataset. Pass exactly one of ``array`` (numpy) or ``tensor`` (torch)."""
         super().__init__(
             array=array,
+            tensor=tensor,
             name=name,
             origin=origin,
             sampling=sampling,

--- a/src/quantem/core/datastructures/dataset4d.py
+++ b/src/quantem/core/datastructures/dataset4d.py
@@ -32,7 +32,27 @@ class Dataset4d(Dataset):
         metadata: dict = {},
         _token: object | None = None,
     ):
-        """Initialize a 4D dataset. Pass exactly one of ``array`` (numpy) or ``tensor`` (torch)."""
+        """Initialize a 4D dataset.
+
+        Parameters
+        ----------
+        array : NDArray | None
+            The underlying 4D numpy array. Provide exactly one of ``array`` or ``tensor``.
+        tensor : torch.Tensor | None
+            The underlying 4D torch tensor (any device). Provide exactly one of ``array`` or ``tensor``.
+        name : str
+            A descriptive name for the dataset
+        origin : NDArray | tuple | list | float | int
+            The origin coordinates for each dimension in calibrated units
+        sampling : NDArray | tuple | list | float | int
+            The sampling rate/spacing for each dimension
+        units : list[str] | tuple | list
+            Units for each dimension
+        signal_units : str, optional
+            Units for the array values, by default "arb. units"
+        _token : object | None, optional
+            Token to prevent direct instantiation, by default None
+        """
         super().__init__(
             array=array,
             tensor=tensor,

--- a/src/quantem/core/datastructures/dataset4dstem.py
+++ b/src/quantem/core/datastructures/dataset4dstem.py
@@ -181,6 +181,8 @@ class Dataset4dstem(Dataset4d):
 
         For cupy / jax arrays, wrap with ``torch.from_dlpack(arr)`` first.
         """
+        # TODO: factor type + ndim checks into `ensure_valid_tensor(value, ndim=4)`
+        # in validators.py, matching `ensure_valid_array` pattern. Cuts bloat.
         if not isinstance(tensor, torch.Tensor):
             raise TypeError(
                 f"from_tensor requires torch.Tensor, got {type(tensor).__name__}. "

--- a/src/quantem/core/datastructures/dataset4dstem.py
+++ b/src/quantem/core/datastructures/dataset4dstem.py
@@ -2,6 +2,7 @@ from typing import Any, Self
 
 import matplotlib.pyplot as plt
 import numpy as np
+import torch
 from matplotlib.patches import Circle, Wedge
 from numpy.typing import NDArray
 
@@ -41,11 +42,12 @@ class Dataset4dstem(Dataset4d):
 
     def __init__(
         self,
-        array: NDArray | Any,
-        name: str,
-        origin: NDArray | tuple | list | float | int,
-        sampling: NDArray | tuple | list | float | int,
-        units: list[str] | tuple | list,
+        array: NDArray | None = None,
+        tensor: torch.Tensor | None = None,
+        name: str = "",
+        origin: NDArray | tuple | list | float | int | None = None,
+        sampling: NDArray | tuple | list | float | int | None = None,
+        units: list[str] | tuple | list | None = None,
         signal_units: str = "arb. units",
         metadata: dict = {},
         _token: object | None = None,
@@ -79,6 +81,7 @@ class Dataset4dstem(Dataset4d):
 
         super().__init__(
             array=array,
+            tensor=tensor,
             name=name,
             origin=origin,
             sampling=sampling,
@@ -154,6 +157,45 @@ class Dataset4dstem(Dataset4d):
             sampling=sampling if sampling is not None else np.ones(4),
             units=units if units is not None else ["pixels"] * 4,
             signal_units=signal_units,
+            _token=cls._token,
+        )
+
+    @classmethod
+    def from_tensor(
+        cls,
+        tensor: torch.Tensor,
+        name: str | None = None,
+        origin: NDArray | tuple | list | float | int | None = None,
+        sampling: NDArray | tuple | list | float | int | None = None,
+        units: list[str] | tuple | list | None = None,
+        signal_units: str = "arb. units",
+        metadata: dict | None = None,
+    ) -> Self:
+        """Create a Dataset4dstem from a torch tensor (any device).
+
+        Use this when raw data is GPU-resident (CUDA pipelines, live detector
+        frames, GPU file readers) to skip the VRAM<->RAM round-trip.
+
+        For cupy / jax arrays, wrap with ``torch.from_dlpack(arr)`` first.
+        """
+        if not isinstance(tensor, torch.Tensor):
+            raise TypeError(
+                f"from_tensor requires torch.Tensor, got {type(tensor).__name__}. "
+                f"For cupy / jax, wrap with `torch.from_dlpack(arr)` first."
+            )
+        if tensor.ndim != 4:
+            raise ValueError(
+                f"Dataset4dstem.from_tensor requires a 4D tensor "
+                f"(scan_y, scan_x, dp_y, dp_x), got shape {tuple(tensor.shape)}."
+            )
+        return cls(
+            tensor=tensor,
+            name=name if name is not None else "4D-STEM dataset (torch)",
+            origin=origin if origin is not None else np.zeros(4),
+            sampling=sampling if sampling is not None else np.ones(4),
+            units=units if units is not None else ["pixels"] * 4,
+            signal_units=signal_units,
+            metadata=metadata if metadata is not None else {},
             _token=cls._token,
         )
 

--- a/src/quantem/core/datastructures/dataset4dstem.py
+++ b/src/quantem/core/datastructures/dataset4dstem.py
@@ -58,6 +58,9 @@ class Dataset4dstem(Dataset4d):
         ----------
         array : NDArray | Any
             The underlying 4D array data
+        tensor : torch.Tensor | None, optional
+            Alternative to ``array``: the underlying 4D torch tensor (any device).
+            Provide exactly one of ``array`` or ``tensor``.
         name : str
             A descriptive name for the dataset
         origin : NDArray | tuple | list | float | int

--- a/src/quantem/core/datastructures/dataset4dstem.py
+++ b/src/quantem/core/datastructures/dataset4dstem.py
@@ -189,7 +189,7 @@ class Dataset4dstem(Dataset4d):
         if tensor.ndim != 4:
             raise ValueError(
                 f"Dataset4dstem.from_tensor requires a 4D tensor "
-                f"(scan_y, scan_x, dp_y, dp_x), got shape {tuple(tensor.shape)}."
+                f"(scan_row, scan_col, dp_row, dp_col), got shape {tuple(tensor.shape)}."
             )
         return cls(
             tensor=tensor,

--- a/tests/datastructures/test_dataset.py
+++ b/tests/datastructures/test_dataset.py
@@ -434,3 +434,21 @@ class TestFourierResample:
         # Neither specified
         with pytest.raises(ValueError):
             sample_dataset_2d.fourier_resample()
+
+
+class TestDatasetTorch:
+    """Tests for torch-backed Dataset (from_tensor path)."""
+
+    def test_numpy_copy_is_readonly(self):
+        """``.numpy()`` on a tensor-backed dataset returns a read-only CPU copy
+        so writes raise instead of silently updating only the detached copy.
+        """
+        import torch
+        from quantem.core.datastructures.dataset4dstem import Dataset4dstem
+        ds = Dataset4dstem.from_tensor(torch.zeros(2, 2, 2, 2))
+        arr = ds.numpy()
+        assert arr.flags.writeable is False
+        with pytest.raises(ValueError, match="read-only"):
+            arr[0, 0, 0, 0] = 99.0
+
+

--- a/widget/src/quantem/widget/show4dstem.py
+++ b/widget/src/quantem/widget/show4dstem.py
@@ -334,9 +334,9 @@ class Show4DSTEM(anywidget.AnyWidget):
         _io_labels = None
 
         # Auto-extract sampling + units from Dataset4dstem if available.
-        # NOTE: avoid `hasattr(data, "array")` — for tensor-backed Datasets the
-        # `.array` getter is an expensive derive (full GPU->CPU copy). Use cheap
-        # `hasattr(data, "sampling")` to identify a Dataset.
+        # NOTE: avoid `hasattr(data, "array")` because for tensor-backed Datasets
+        # the `.array` getter is an expensive derive (full GPU->CPU copy). Use
+        # cheap `hasattr(data, "sampling")` to identify a Dataset.
         if hasattr(data, "sampling"):
             if not title and hasattr(data, "name") and data.name:
                 title = str(data.name)

--- a/widget/src/quantem/widget/show4dstem.py
+++ b/widget/src/quantem/widget/show4dstem.py
@@ -334,14 +334,21 @@ class Show4DSTEM(anywidget.AnyWidget):
         _io_labels = None
 
         # Auto-extract sampling + units from Dataset4dstem if available.
-        if hasattr(data, "sampling") and hasattr(data, "array"):
+        # NOTE: avoid `hasattr(data, "array")` — for tensor-backed Datasets the
+        # `.array` getter is an expensive derive (full GPU->CPU copy). Use cheap
+        # `hasattr(data, "sampling")` to identify a Dataset.
+        if hasattr(data, "sampling"):
             if not title and hasattr(data, "name") and data.name:
                 title = str(data.name)
             if sampling is None:
                 sampling = tuple(float(s) for s in data.sampling)
             if units is None and hasattr(data, "units"):
                 units = list(data.units)
-            data = data.array
+            # If tensor-backed (zero-copy GPU path), take .tensor. Else .array (numpy).
+            if getattr(data, "_tensor", None) is not None:
+                data = data.tensor
+            else:
+                data = data.array
 
         # Resolve sampling + units (4 axes for 4D-STEM):
         # [scan_row, scan_col, k_row, k_col]. Scalar/None broadcast to (1, 1, 1, 1).

--- a/widget/src/quantem/widget/show4dstem.py
+++ b/widget/src/quantem/widget/show4dstem.py
@@ -333,22 +333,18 @@ class Show4DSTEM(anywidget.AnyWidget):
 
         _io_labels = None
 
-        # Auto-extract sampling + units from Dataset4dstem if available.
-        # NOTE: avoid `hasattr(data, "array")` because for tensor-backed Datasets
-        # the `.array` getter is an expensive derive (full GPU->CPU copy). Use
-        # cheap `hasattr(data, "sampling")` to identify a Dataset.
-        if hasattr(data, "sampling"):
-            if not title and hasattr(data, "name") and data.name:
+        # Extract underlying array / tensor + auto-calibrate from Dataset input
+        # (duck-typed via the dual-slot private attributes _tensor / _array).
+        tensor = getattr(data, "_tensor", None)
+        array = getattr(data, "_array", None)
+        if tensor is not None or array is not None:
+            if not title and getattr(data, "name", ""):
                 title = str(data.name)
             if sampling is None:
                 sampling = tuple(float(s) for s in data.sampling)
-            if units is None and hasattr(data, "units"):
+            if units is None:
                 units = list(data.units)
-            # If tensor-backed (zero-copy GPU path), take .tensor. Else .array (numpy).
-            if getattr(data, "_tensor", None) is not None:
-                data = data.tensor
-            else:
-                data = data.array
+            data = tensor if tensor is not None else array
 
         # Resolve sampling + units (4 axes for 4D-STEM):
         # [scan_row, scan_col, k_row, k_col]. Scalar/None broadcast to (1, 1, 1, 1).


### PR DESCRIPTION
### What problem this PR addreseses

A long discussion has been initiated here: https://github.com/electronmicroscopy/quantem/issues/222 with action plan in https://github.com/electronmicroscopy/quantem/issues/222#issuecomment-4482058601

tl;dr - allow `datset4dstem` to hold torch tensor, w/o breaking existing notebooks and codes.

API

```
# Existing — unchanged
Dataset4dstem.from_array(numpy_arr, sampling=..., units=..., name=...)

# New — GPU-resident path
Dataset4dstem.from_tensor(torch_tensor, sampling=..., units=..., name=...)

Access

┌─────────────────────────────┬─────────────────────────────┬───────────────────────────────────────────────────┐
│      Property / Method      │  numpy-backed (from_array)  │            tensor-backed (from_tensor)            │
├─────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────┤
│ dset.array                  │ np.ndarray                  │ None (use .tensor)                                │
├─────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────┤
│ dset.tensor                 │ AttributeError              │ torch.Tensor                                      │
├─────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────┤
│ dset.numpy()                │ np.ndarray (same as .array) │ np.ndarray (CPU copy via .detach().cpu().numpy()) │
├─────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────┤
│ dset.device                 │ "cpu"                       │ "cuda:0" / "mps" / "cpu"                          │
├─────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────┤
│ dset.to(device)             │ AttributeError              │ moves tensor, returns self                        │
├─────────────────────────────┼─────────────────────────────┼───────────────────────────────────────────────────┤
│ dset.shape / .ndim / .dtype │ from numpy                  │ from tensor                                       │
└─────────────────────────────┴─────────────────────────────┴───────────────────────────────────────────────────┘

```



May 22, 2026 update

Verification:

Widget:

<img width="717" height="651" alt="Screenshot 2026-05-22 at 11 25 32 PM" src="https://github.com/user-attachments/assets/4cb90039-f83a-4b86-a8d5-0f591b12c549" />

Ptycho notebook:

<img width="1007" height="1037" alt="Screenshot 2026-05-22 at 11 23 32 PM" src="https://github.com/user-attachments/assets/39509e26-9810-44e9-b7d4-1f8afd591cc4" />

<img width="763" height="592" alt="Screenshot 2026-05-22 at 11 24 22 PM" src="https://github.com/user-attachments/assets/82e87239-caed-4da6-b84a-ddbc2f20edfc" />

Direct ptycho noteobok:

<img width="1014" height="583" alt="Screenshot 2026-05-22 at 11 26 15 PM" src="https://github.com/user-attachments/assets/7bbfeebc-31d5-48a8-9cd1-3d810604c056" />



### What should the reviewer(s) do

Arthur's comment: https://github.com/electronmicroscopy/quantem/issues/222#issuecomment-4482058601

- [x] non-breaking just adding basic torch support
- [x] in base Dataset dset.tensor # is None if not set, `.tensor` and `.array`, but only one of them will be set (raises `AttributeError` for explicitness)
- [x] Dataset4dstem: `dset.from_tensor` classmethod
- [x] dset.device (just return self.tensor.device)
- [x] dset.to (just moving dset.tensor)
- [x] dset.numpy() method (will be required in the future, make it now so people get used to it)

