### PR TITLE
Fix latent bugs in tomography optimizer wiring, constraints, and radon

### DIFF
--- a/src/quantem/tomography/dataset_models.py
+++ b/src/quantem/tomography/dataset_models.py
@@ -486,8 +486,6 @@ class TomographyINRDataset(TomographyDatasetConstraints, Dataset):
             return shifts, torch.zeros_like(z1), torch.zeros_like(z3)
         elif self.learn_tilt_axis:
             return torch.zeros_like(shifts), z1, z3
-        elif self.learn_shift and self.learn_tilt_axis:
-            return shifts, z1, z3
         else:
             return torch.zeros_like(shifts), torch.zeros_like(z1), torch.zeros_like(z3)
 

--- a/src/quantem/tomography/object_models.py
+++ b/src/quantem/tomography/object_models.py
@@ -101,7 +101,7 @@ class ObjConstraintParams:
         sparsity: float = 0.0
         _name: str = "obj_inr"
 
-        soft_constraint_keys = ["tv_vol", "tv_plane", "sparsity"]
+        soft_constraint_keys = ["tv_vol", "sparsity"]
         hard_constraint_keys = ["positivity", "shrinkage"]
 
     @dataclass
@@ -436,12 +436,16 @@ class ObjectPixelated(ObjectConstraints):
     # --- Defining the TV loss ---
     def get_tv_loss(self, ctx: ReconstructionContext) -> torch.Tensor:
         assert ctx.obj is not None, "ObjectPixelated requires ctx.obj to be set"
-        tv_d = torch.pow(ctx.obj[:, :, 1:, :, :] - ctx.obj[:, :, :-1, :, :], 2).sum()
-        tv_h = torch.pow(ctx.obj[:, :, :, 1:, :] - ctx.obj[:, :, :, :-1, :], 2).sum()
-        tv_w = torch.pow(ctx.obj[:, :, :, :, 1:] - ctx.obj[:, :, :, :, :-1], 2).sum()
+        # TV over the three trailing spatial dims, leaving any leading channel/batch axes
+        # intact. Works for a 3-D volume, obj_view's [1, D, H, W], and a multimodal
+        # [C, D, H, W] (channels = elemental compositions), matching the INR / tensor-decomp
+        # convention where the object carries a leading channel dimension.
+        tv_d = torch.pow(ctx.obj[..., 1:, :, :] - ctx.obj[..., :-1, :, :], 2).sum()
+        tv_h = torch.pow(ctx.obj[..., :, 1:, :] - ctx.obj[..., :, :-1, :], 2).sum()
+        tv_w = torch.pow(ctx.obj[..., :, :, 1:] - ctx.obj[..., :, :, :-1], 2).sum()
         tv_loss = tv_d + tv_h + tv_w
 
-        return tv_loss * self.constraints.tv_vol / (torch.prod(torch.tensor(ctx.obj.shape)))
+        return tv_loss * self.constraints.tv_vol / ctx.obj.numel()
 
     # --- Helper Functions ---
     def to(self, device: str | torch.device):
@@ -934,7 +938,7 @@ class ObjectTensorDecomp(ObjectINR):
         Gets the summed total variational loss for the tensor decomposition model.
 
         _get_plane_tv_loss: Total-variation across the planes.
-        _get_volume_tv_loss: Isotropic volume TV 
+        _get_volume_tv_loss: Isotropic volume TV
         """
         assert ctx.coords is not None, "Coordinates must be provided for TV loss"
         assert ctx.pred is not None, "Prediction must be provided for TV loss"

--- a/src/quantem/tomography/radon/radon.py
+++ b/src/quantem/tomography/radon/radon.py
@@ -91,7 +91,8 @@ def iradon_torch(
         sinograms = sinograms.unsqueeze(0)
     B, A, N = sinograms.shape
     device = device or sinograms.device
-    theta = theta if theta is not None else torch.linspace(0, 180, steps=A, device=device)
+    # Match radon_torch / scikit-image: A angles evenly spanning [0, 180) (endpoint excluded).
+    theta = theta if theta is not None else torch.linspace(0, 180, steps=A + 1, device=device)[:-1]
 
     if output_size is None:
         output_size = N if circle else int((N**2 / 2) ** 0.5)

--- a/src/quantem/tomography/tomography.py
+++ b/src/quantem/tomography/tomography.py
@@ -143,7 +143,7 @@ class Tomography(TomographyOpt, TomographyBase):
                     self.set_optimizers()
                 if scheduler_params is not None:
                     self.scheduler_params = scheduler_params
-                    self.set_schedulers(self.scheduler_params)
+                    self.set_schedulers(self.scheduler_params, num_iter=num_iter)
 
             self.dataloader, self.sampler, self.val_dataloader, self.val_sampler = (
                 self.setup_dataloader(

--- a/src/quantem/tomography/tomography_opt.py
+++ b/src/quantem/tomography/tomography_opt.py
@@ -114,7 +114,8 @@ class TomographyOpt(TomographyBase):
     @scheduler_params.setter
     def scheduler_params(self, d: dict):
         """Set the scheduler parameters."""
-        self._scheduler_params = d.copy() if d else {}
+        d = dict(d) if d else {}
+        self._scheduler_params = d.copy()
 
         for key in self.OPTIMIZABLE_VALS:
             if key not in d:
@@ -152,21 +153,21 @@ class TomographyOpt(TomographyBase):
 
     def step_optimizers(self):
         for key in self.optimizer_params.keys():
-            if self.obj_model.has_optimizer():
-                self.obj_model.step_optimizer()
-            if self.dset.has_optimizer():
-                self.dset.step_optimizer()
             if key not in self.OPTIMIZABLE_VALS:
                 raise ValueError(f"Unknown optimization key: {key}")
+            if key == "object" and self.obj_model.has_optimizer():
+                self.obj_model.step_optimizer()
+            elif key == "pose" and self.dset.has_optimizer():
+                self.dset.step_optimizer()
 
     def zero_grad_all(self):
         for key in self.optimizer_params.keys():
-            if self.obj_model.has_optimizer():
-                self.obj_model.zero_optimizer_grad()
-            if self.dset.has_optimizer():
-                self.dset.zero_optimizer_grad()
             if key not in self.OPTIMIZABLE_VALS:
                 raise ValueError(f"Unknown optimization key: {key}")
+            if key == "object" and self.obj_model.has_optimizer():
+                self.obj_model.zero_optimizer_grad()
+            elif key == "pose" and self.dset.has_optimizer():
+                self.dset.zero_optimizer_grad()
 
     def step_schedulers(self, loss: float | None = None):
         for key in self.scheduler_params.keys():

--- a/tests/tomography/test_dataset_models.py
+++ b/tests/tomography/test_dataset_models.py
@@ -95,6 +95,35 @@ class TestTomographyINRDataset:
         item = d[0]
         assert {"phi", "pixel_i", "pixel_j", "projection_idx", "target_value"} <= set(item.keys())
 
+    @pytest.mark.parametrize(
+        "learn_shift,learn_tilt_axis",
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_forward_gates_shift_and_tilt(self, learn_shift, learn_tilt_axis):
+        """``forward`` zeros the disabled component and passes the enabled one through.
+
+        Guards the gating after removing the unreachable duplicate branch: shifts are
+        controlled by ``learn_shift``; the z1/z3 Euler angles by ``learn_tilt_axis``.
+        """
+        d = TomographyINRDataset.from_data(
+            _stack(nang=5, n=12),
+            np.linspace(-60, 60, 5, dtype="f4"),
+            learn_shift=learn_shift,
+            learn_tilt_axis=learn_tilt_axis,
+        )
+        d.to("cpu")
+        # Make every pose parameter non-zero so the gating is observable by value.
+        for p in (d.z1_params, d.z3_params, d.shifts_params):
+            p.data.fill_(1.0)
+        d._z1_ref = torch.ones_like(d._z1_ref)
+        d._z3_ref = torch.ones_like(d._z3_ref)
+        d._shifts_ref = torch.ones_like(d._shifts_ref)
+
+        shifts, z1, z3 = d.forward(None)
+        assert bool(shifts.any()) == learn_shift
+        assert bool(z1.any()) == learn_tilt_axis
+        assert bool(z3.any()) == learn_tilt_axis
+
 
 class TestTomographyINRPretrainDataset:
     def test_len_and_getitem(self):

--- a/tests/tomography/test_object_models.py
+++ b/tests/tomography/test_object_models.py
@@ -50,6 +50,22 @@ class TestObjConstraintParse:
         assert "positivity" in c.hard_constraint_keys
         assert "tv_vol" in c.soft_constraint_keys
 
+    def test_constraint_keys_are_real_fields(self):
+        """Regression: every soft/hard key must be an attribute, so __str__ never raises.
+
+        ``ObjINRConstraints`` previously listed ``tv_plane`` (a field it does not have), which
+        made ``str(constraints)`` blow up with AttributeError via ``Constraints.__str__``.
+        """
+        for cls in (
+            ObjConstraintParams.ObjPixelatedConstraints,
+            ObjConstraintParams.ObjINRConstraints,
+            ObjConstraintParams.ObjTensorDecompConstraints,
+        ):
+            c = cls()
+            for key in c.soft_constraint_keys + c.hard_constraint_keys:
+                assert hasattr(c, key), f"{cls.__name__} lists missing key {key!r}"
+            assert isinstance(str(c), str)  # must not raise
+
 
 class TestObjectPixelatedConstruction:
     def test_from_uniform_is_zeros(self):
@@ -98,7 +114,8 @@ class TestObjectPixelatedConstraints:
         assert torch.allclose(obj.obj, torch.full((4, 4, 4), 0.75))
 
     def test_tv_loss_scales_with_weight(self):
-        ctx = ReconstructionContext(obj=torch.rand(1, 1, 8, 8, 8))
+        # ctx.obj is the 3-D pixelated volume (D, H, W), matching ObjectPixelated._obj.
+        ctx = ReconstructionContext(obj=torch.rand(8, 8, 8))
         obj = ObjectPixelated.from_uniform(shape=(8, 8, 8), device="cpu")
         obj.constraints.tv_vol = 1.0
         loss1 = obj.get_tv_loss(ctx)
@@ -106,8 +123,27 @@ class TestObjectPixelatedConstraints:
         loss2 = obj.get_tv_loss(ctx)
         assert torch.isclose(loss2, 2.0 * loss1)
 
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (8, 8, 8),  # bare 3-D volume
+            (1, 8, 8, 8),  # obj_view layout [C=1, D, H, W]
+            (3, 8, 8, 8),  # multimodal [C, D, H, W] (e.g. 3 elemental channels)
+        ],
+    )
+    def test_tv_loss_rank_agnostic_finite_and_positive(self, shape):
+        """Regression: get_tv_loss takes TV over the trailing spatial dims for any leading
+        channel/batch axes -- not the old 5-D-only indexing. Supports multimodal [C, ...]."""
+        ctx = ReconstructionContext(obj=torch.rand(*shape))
+        obj = ObjectPixelated.from_uniform(shape=(8, 8, 8), device="cpu")
+        obj.constraints.tv_vol = 1.0
+        loss = obj.get_tv_loss(ctx)
+        assert loss.ndim == 0
+        assert torch.isfinite(loss)
+        assert loss > 0.0  # random volume has non-zero total variation
+
     def test_soft_constraint_zero_when_tv_off(self):
-        ctx = ReconstructionContext(obj=torch.rand(1, 1, 8, 8, 8))
+        ctx = ReconstructionContext(obj=torch.rand(8, 8, 8))
         obj = ObjectPixelated.from_uniform(shape=(8, 8, 8), device="cpu")
         obj.constraints.tv_vol = 0.0
         assert float(obj.apply_soft_constraints(ctx).detach()) == 0.0

--- a/tests/tomography/test_radon.py
+++ b/tests/tomography/test_radon.py
@@ -95,6 +95,17 @@ class TestRadonBehaviour:
         corr = np.corrcoef(disk.numpy().ravel(), rec.numpy().ravel())[0, 1]
         assert corr > 0.9
 
+    def test_default_theta_roundtrip_is_consistent(self):
+        """radon and iradon must share an angle convention when ``theta`` is defaulted.
+
+        iradon's default previously included the 180-degree endpoint while radon's did not,
+        so a default-theta round-trip sampled mismatched angles.
+        """
+        disk = _disk(64, 32, 28, 10)
+        rec = iradon_torch(radon_torch(disk), filter_name="ramp")  # both default theta
+        corr = np.corrcoef(disk.numpy().ravel(), rec.numpy().ravel())[0, 1]
+        assert corr > 0.9
+
 
 class TestRadonVsSkimage:
     """Loose cross-check against scikit-image's reference implementation."""

--- a/tests/tomography/test_tomography_opt.py
+++ b/tests/tomography/test_tomography_opt.py
@@ -112,6 +112,54 @@ class TestOptimizerParams:
         assert len(tomo.optimizers["object"].param_groups) == 3
         assert "pose" in tomo.optimizers
 
+    def test_step_optimizers_steps_each_once(self, torch_device, monkeypatch):
+        """Regression: with object+pose, each optimizer must step exactly once per call.
+
+        ``step_optimizers`` previously looped over both keys and stepped *both* optimizers on
+        every pass, so each took two Adam steps per batch.
+        """
+        tomo = _inr_tomography(torch_device)
+        tomo.optimizer_params = {
+            "object": OptimizerParams.Adam(lr=1e-3),
+            "pose": OptimizerParams.Adam(lr=1e-2),
+        }
+        tomo.set_optimizers()
+        assert set(tomo.optimizers.keys()) == {"object", "pose"}  # both optimizers live
+
+        counts = {"object": 0, "pose": 0}
+        monkeypatch.setattr(
+            tomo.obj_model,
+            "step_optimizer",
+            lambda: counts.__setitem__("object", counts["object"] + 1),
+        )
+        monkeypatch.setattr(
+            tomo.dset, "step_optimizer", lambda: counts.__setitem__("pose", counts["pose"] + 1)
+        )
+        tomo.step_optimizers()
+        assert counts == {"object": 1, "pose": 1}
+
+    def test_zero_grad_all_zeros_each_once(self, torch_device, monkeypatch):
+        """Companion to the step regression: zero_grad_all must touch each optimizer once."""
+        tomo = _inr_tomography(torch_device)
+        tomo.optimizer_params = {
+            "object": OptimizerParams.Adam(lr=1e-3),
+            "pose": OptimizerParams.Adam(lr=1e-2),
+        }
+        tomo.set_optimizers()
+        counts = {"object": 0, "pose": 0}
+        monkeypatch.setattr(
+            tomo.obj_model,
+            "zero_optimizer_grad",
+            lambda: counts.__setitem__("object", counts["object"] + 1),
+        )
+        monkeypatch.setattr(
+            tomo.dset,
+            "zero_optimizer_grad",
+            lambda: counts.__setitem__("pose", counts["pose"] + 1),
+        )
+        tomo.zero_grad_all()
+        assert counts == {"object": 1, "pose": 1}
+
 
 @requires_torch
 class TestSchedulerParams:
@@ -141,3 +189,10 @@ class TestSchedulerParams:
         tomo = _inr_tomography(torch_device)
         with pytest.raises(TypeError):
             tomo.obj_model.scheduler_params = 123
+
+    def test_setter_does_not_mutate_caller_dict(self, torch_device):
+        """Regression: the setter must not inject missing keys into the caller's dict."""
+        tomo = _inr_tomography(torch_device)
+        d = {"object": SchedulerParams.CosineAnnealing(T_max=10)}
+        tomo.scheduler_params = d
+        assert set(d.keys()) == {"object"}  # "pose" must not have been added to the input


### PR DESCRIPTION
# What problem this PR addreseses

step_optimizers and zero_grad_all looped over optimizer_params and stepped both the object and pose optimizers on every pass, so with pose optimization enabled each optimizer took two Adam steps per batch. Gate by key, matching step_schedulers.

Also:
- pass num_iter to set_schedulers on the reset_dset path so cosine/linear/ exponential schedulers get a valid T_max
- scheduler_params setter no longer mutates the caller's dict
- drop the non-existent tv_plane key from ObjINRConstraints.soft_constraint_keys (it crashed Constraints.__str__)
- ObjectPixelated.get_tv_loss now takes TV over the trailing spatial dims, so it handles a 3D volume, obj_view's [1, D, H, W], and a multimodal [C, D, H, W]
- remove an unreachable duplicate branch in TomographyINRDataset.forward
- align iradon_torch's default theta with radon_torch / scikit-image (endpoint excluded)

Add regression tests covering each fix.

# What Reviewer Should Do

Nothing - all tests pass checking for these fixes.
