### PR TITLE
Direct ptycho visualize and rotation

### DIFF
--- a/src/quantem/diffractive_imaging/direct_ptycho_utils.py
+++ b/src/quantem/diffractive_imaging/direct_ptycho_utils.py
@@ -495,7 +495,10 @@ def fit_aberrations_from_shifts(
     gpts: tuple[int, int],
     sampling: tuple[float, float],
 ) -> dict[str, float]:
-    """ """
+    """Fit low-order aberrations from lateral shifts.
+
+    Returns ``rotation_angle`` in degrees.
+    """
     device = shifts_ang.device
 
     # Get spatial frequencies at BF positions
@@ -534,7 +537,7 @@ def fit_aberrations_from_shifts(
         "C10": C10.item(),
         "C12": C12.item(),
         "phi12": phi12.item(),
-        "rotation_angle": rotation_rad.item(),
+        "rotation_angle": torch.rad2deg(rotation_rad).item(),
     }
 
 

--- a/src/quantem/diffractive_imaging/direct_ptycho_utils.py
+++ b/src/quantem/diffractive_imaging/direct_ptycho_utils.py
@@ -37,6 +37,12 @@ ABERRATION_PRESETS = {
 # fmt: on
 
 
+def _rotation_degrees_to_radians(rotation_angle: float | None) -> float | None:
+    if rotation_angle is None:
+        return None
+    return math.radians(float(rotation_angle))
+
+
 def create_edge_window(shape, edge_blend_pixels, device="cpu"):
     """
     Create a smooth edge window that transitions from 0 at edges to 1 in center.

--- a/src/quantem/diffractive_imaging/direct_ptychography.py
+++ b/src/quantem/diffractive_imaging/direct_ptychography.py
@@ -45,6 +45,7 @@ from itertools import product
 from quantem.diffractive_imaging.direct_ptycho_utils import (
     ABERRATION_PRESETS,
     _crop_corner_centered_mask,
+    _rotation_degrees_to_radians,
     align_vbf_stack_multiscale,
     create_edge_window,
     fit_aberrations_from_shifts,
@@ -53,12 +54,6 @@ from quantem.diffractive_imaging.direct_ptycho_utils import (
 )
 
 optuna.logging.set_verbosity(optuna.logging.WARNING)
-
-
-def _rotation_degrees_to_radians(rotation_angle: float | None) -> float | None:
-    if rotation_angle is None:
-        return None
-    return math.radians(float(rotation_angle))
 
 
 @dataclass
@@ -914,6 +909,8 @@ class DirectPtychography(RNGMixin, AutoSerialize):
     def visualize(
         self,
         return_fig: bool = False,
+        show_obj_fft: bool = True,
+        apply_hanning_window: bool = False,
         **kwargs,
     ):
         """
@@ -934,20 +931,32 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             raise RuntimeError("Run reconstruct() before visualize().")
 
         obj = self.obj
-        window = np.hanning(obj.shape[-2])[:, None] * np.hanning(obj.shape[-1])[None, :]
-        obj_fft = np.fft.fftshift(np.fft.fft2(obj * window))
+        obj_scalebar = {"sampling": self.scan_sampling[1], "units": "Å"}
 
-        obj_scalebar = {"sampling": self.scan_sampling[0], "units": "Å"}
-        fft_sampling = 1 / (self.scan_sampling[0] * obj.shape[-2])
-        fft_scalebar = {"sampling": fft_sampling, "units": r"$\mathrm{A^{-1}}$"}
+        if show_obj_fft:
+            if apply_hanning_window:
+                window = np.hanning(obj.shape[-2])[:, None] * np.hanning(obj.shape[-1])[None, :]
+                obj_fft = np.fft.fftshift(np.abs(np.fft.fft2(obj * window)))
+            else:
+                obj_fft = np.fft.fftshift(np.abs(np.fft.fft2(obj)))
 
-        fig, axs = show_2d(
-            [obj, np.abs(obj_fft)],
-            title=["Object", "Object FFT"],
-            scalebar=[obj_scalebar, fft_scalebar],
-            **kwargs,
-        )
-        axs[1].set_aspect(obj.shape[-1] / obj.shape[-2])
+            fft_sampling = 1 / (self.scan_sampling[1] * obj.shape[-1])
+            fft_scalebar = {"sampling": fft_sampling, "units": r"$\mathrm{A^{-1}}$"}
+
+            fig, axs = show_2d(
+                [obj, obj_fft],
+                title=["Object phase", "Object phase FFT"],
+                scalebar=[obj_scalebar, fft_scalebar],
+                **kwargs,
+            )
+            axs[1].set_aspect(obj.shape[-1] / obj.shape[-2])
+        else:
+            fig, axs = show_2d(
+                obj,
+                title="Object phase",
+                scalebar=obj_scalebar,
+                **kwargs,
+            )
 
         if return_fig:
             return fig, axs

--- a/src/quantem/diffractive_imaging/direct_ptychography.py
+++ b/src/quantem/diffractive_imaging/direct_ptychography.py
@@ -54,6 +54,12 @@ from quantem.diffractive_imaging.direct_ptycho_utils import (
 optuna.logging.set_verbosity(optuna.logging.WARNING)
 
 
+def _rotation_degrees_to_radians(rotation_angle: float | None) -> float | None:
+    if rotation_angle is None:
+        return None
+    return math.radians(float(rotation_angle))
+
+
 @dataclass
 class OptimizationParameter:
     low: float
@@ -156,13 +162,13 @@ class HyperparameterState:
             if self.initial_aberrations:
                 add("initial_aberrations", self.initial_aberrations)
             if self.initial_rotation_angle is not None:
-                add("initial_rotation_angle", self.initial_rotation_angle)
+                add("initial_rotation_angle_deg", self.initial_rotation_angle)
 
         elif which == "optimized":
             if self.optimized_aberrations:
                 add("optimized_aberrations", self.optimized_aberrations)
             if self.optimized_rotation_angle is not None:
-                add("optimized_rotation_angle", self.optimized_rotation_angle)
+                add("optimized_rotation_angle_deg", self.optimized_rotation_angle)
 
         elif which == "current":
             current_abers = self.current_aberrations(override_aberration_coefs)
@@ -171,17 +177,17 @@ class HyperparameterState:
             if current_abers:
                 add("current_aberrations", current_abers)
             if current_rot is not None:
-                add("current_rotation_angle", current_rot)
+                add("current_rotation_angle_deg", current_rot)
 
         elif which == "all":
             if self.initial_aberrations:
                 add("initial_aberrations", self.initial_aberrations)
             if self.initial_rotation_angle is not None:
-                add("initial_rotation_angle", self.initial_rotation_angle)
+                add("initial_rotation_angle_deg", self.initial_rotation_angle)
             if self.optimized_aberrations:
                 add("optimized_aberrations", self.optimized_aberrations)
             if self.optimized_rotation_angle is not None:
-                add("optimized_rotation_angle", self.optimized_rotation_angle)
+                add("optimized_rotation_angle_deg", self.optimized_rotation_angle)
 
         else:
             raise ValueError(
@@ -335,7 +341,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         if rotation_angle is None:
             origin.estimate_detector_rotation()
-            rotation_angle = origin.detector_rotation_deg / 180 * math.pi
+            rotation_angle = origin.detector_rotation_deg
 
         # shift to origin
         origin.shift_origin_to(
@@ -494,6 +500,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
     @property
     def rotation_angle(self) -> float:
+        """Current detector rotation angle in degrees."""
         return self.hyperparameter_state.current_rotation_angle()
 
     @property
@@ -679,7 +686,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         upsampling_factor : int, optional
             Factor by which to upsample the reconstruction
         override_rotation_angle : float, optional
-            Rotation angle for coordinate system
+            Rotation angle for coordinate system, in degrees
         max_batch_size : int, optional
             Maximum batch size for processing
         deconvolution_kernel : str, one of ['ssb', 'obf', 'mf','prlx','icom']
@@ -742,7 +749,10 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         # Get k-space grid
         kxa, kya = spatial_frequencies(
-            self.gpts, self.sampling, rotation_angle=rotation_angle, device=self.device
+            self.gpts,
+            self.sampling,
+            rotation_angle=_rotation_degrees_to_radians(rotation_angle),
+            device=self.device,
         )
         k, phi = polar_coordinates(kxa, kya)
 
@@ -917,7 +927,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         aberration_coefs : dict[str, float|OptimizationParameter]
             Dict of aberration names to either fixed values or optimization ranges.
         rotation_angle : float|OptimizationParameter
-            Fixed rotation or optimization range.
+            Fixed rotation or optimization range, in degrees.
         n_trials : int
             Number of Optuna trials.
         sampler : optuna.samplers.BaseSampler, optional
@@ -1107,7 +1117,10 @@ class DirectPtychography(RNGMixin, AutoSerialize):
     ):
         # Get initial shifts
         kxa, kya = spatial_frequencies(
-            self.gpts, self.sampling, rotation_angle=rotation_angle, device=self.device
+            self.gpts,
+            self.sampling,
+            rotation_angle=_rotation_degrees_to_radians(rotation_angle),
+            device=self.device,
         )
         k, phi = polar_coordinates(kxa, kya)
 
@@ -1335,7 +1348,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         kxa, kya = spatial_frequencies(
             self.gpts,
             self.sampling,
-            rotation_angle=rotation_angle,
+            rotation_angle=_rotation_degrees_to_radians(rotation_angle),
             device=device,
         )
 
@@ -1511,7 +1524,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         Args:
             aberration_coefs: Initial aberration coefficients to deconvolve
-            rotation_angle: Rotation angle for basis functions
+            rotation_angle: Rotation angle for basis functions, in degrees
             cartesian_basis: Aberration basis to fit. Can be:
                 - str: preset name like "low_order"
                 - list[str]: explicit list like ["C10", "C12_a", "C12_b", ...]

--- a/src/quantem/diffractive_imaging/direct_ptychography.py
+++ b/src/quantem/diffractive_imaging/direct_ptychography.py
@@ -945,8 +945,6 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             [obj, np.abs(obj_fft)],
             title=["Object", "Object FFT"],
             scalebar=[obj_scalebar, fft_scalebar],
-            cmap=["magma", "magma"],
-            norm=[None, None],
             **kwargs,
         )
         axs[1].set_aspect(obj.shape[-1] / obj.shape[-2])

--- a/src/quantem/diffractive_imaging/direct_ptychography.py
+++ b/src/quantem/diffractive_imaging/direct_ptychography.py
@@ -60,6 +60,19 @@ def _rotation_degrees_to_radians(rotation_angle: float | None) -> float | None:
     return math.radians(float(rotation_angle))
 
 
+def _uses_aberration_orientation_convention(key: str) -> bool:
+    return key.startswith("phi") or key.endswith("_b")
+
+
+def _aberration_coefs_to_direct_convention(
+    aberration_coefs: dict[str, float | torch.Tensor],
+) -> dict[str, float | torch.Tensor]:
+    return {
+        key: -value if _uses_aberration_orientation_convention(key) else value
+        for key, value in aberration_coefs.items()
+    }
+
+
 @dataclass
 class OptimizationParameter:
     low: float
@@ -726,6 +739,8 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             aberration_coefs = state.current_aberrations(override_aberration_coefs)
             rotation_angle = state.current_rotation_angle(override_rotation_angle)
 
+        direct_aberration_coefs = _aberration_coefs_to_direct_convention(aberration_coefs)
+
         if upsampling_factor is None:
             upsampling_factor = 1
         upsampling_factor = math.ceil(upsampling_factor)
@@ -761,7 +776,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             dx, dy = aberration_surface_cartesian_gradients(
                 k * self.wavelength,
                 phi,
-                aberration_coefs=aberration_coefs,
+                aberration_coefs=direct_aberration_coefs,
             )
             grad_k = torch.stack((dx[bf_mask], dy[bf_mask]), -1)
 
@@ -770,7 +785,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
                     q * self.wavelength,
                     theta,
                     self.wavelength,
-                    aberration_coefs=aberration_coefs,
+                    aberration_coefs=direct_aberration_coefs,
                 )
                 sign_sin_chi_q = torch.sign(torch.sin(chi_q))
             else:
@@ -786,7 +801,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             self.semiangle_cutoff,
             self.angular_sampling,
             self.wavelength,
-            aberration_coefs=aberration_coefs,
+            aberration_coefs=direct_aberration_coefs,
         )
         BF_weights = cmplx_probe_k[bf_mask].abs().square().sum()
 
@@ -830,7 +845,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
                 cmplx_probe_k,
                 grad_k,
                 sign_sin_chi_q,
-                aberration_coefs,
+                direct_aberration_coefs,
                 batch_idx,
             )
             if power is None:
@@ -1115,6 +1130,8 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         aberration_coefs,
         bf_mask,
     ):
+        direct_aberration_coefs = _aberration_coefs_to_direct_convention(aberration_coefs)
+
         # Get initial shifts
         kxa, kya = spatial_frequencies(
             self.gpts,
@@ -1127,7 +1144,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         dx, dy = aberration_surface_cartesian_gradients(
             k * self.wavelength,
             phi,
-            aberration_coefs=aberration_coefs,
+            aberration_coefs=direct_aberration_coefs,
         )
         grad_k = torch.stack((dx[bf_mask], dy[bf_mask]), -1)
         lateral_shifts = grad_k / 2 / np.pi
@@ -1269,8 +1286,8 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         self.corrected_stack = vbf_stack
 
-        fitted_aberration_coefs = fit_results.copy()
-        fitted_rotation_angle = fitted_aberration_coefs.pop("rotation_angle", None)
+        fitted_rotation_angle = fit_results.pop("rotation_angle", None)
+        fitted_aberration_coefs = _aberration_coefs_to_direct_convention(fit_results)
 
         state.optimized_aberrations = validate_aberration_coefficients(fitted_aberration_coefs)
         state.optimized_rotation_angle = fitted_rotation_angle
@@ -1330,6 +1347,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         device = self.device
         wavelength = self.wavelength
+        direct_aberration_coefs = _aberration_coefs_to_direct_convention(aberration_coefs)
 
         # ---------------------------------------------------------
         # Select strongest spatial frequencies
@@ -1381,9 +1399,9 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             km * wavelength, phim, self.semiangle_cutoff, self.angular_sampling, soft_edges=True
         )
 
-        chi0 = aberration_surface(k0 * wavelength, phi0, wavelength, aberration_coefs)
-        chip = aberration_surface(kp * wavelength, phip, wavelength, aberration_coefs)
-        chim = aberration_surface(km * wavelength, phim, wavelength, aberration_coefs)
+        chi0 = aberration_surface(k0 * wavelength, phi0, wavelength, direct_aberration_coefs)
+        chip = aberration_surface(kp * wavelength, phip, wavelength, direct_aberration_coefs)
+        chim = aberration_surface(km * wavelength, phim, wavelength, direct_aberration_coefs)
 
         # ---------------------------------------------------------
         # Overlap-only masks
@@ -1502,7 +1520,8 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         delta_cartesian = {name: sol[i] for i, name in enumerate(cartesian_basis)}
 
-        return merge_aberration_coefficients(aberration_coefs, delta_cartesian)
+        direct_merged = merge_aberration_coefficients(direct_aberration_coefs, delta_cartesian)
+        return _aberration_coefs_to_direct_convention(direct_merged)
 
     def fit_hyperparameters_least_squares(
         self,

--- a/src/quantem/diffractive_imaging/direct_ptychography.py
+++ b/src/quantem/diffractive_imaging/direct_ptychography.py
@@ -19,6 +19,7 @@ from quantem.core.utils.validators import (
     validate_int,
     validate_tensor,
 )
+from quantem.core.visualization import show_2d
 from quantem.diffractive_imaging.complex_probe import (
     aberration_surface,
     aberration_surface_cartesian_basis,
@@ -924,6 +925,50 @@ class DirectPtychography(RNGMixin, AutoSerialize):
     def obj(self) -> np.ndarray:
         obj = to_numpy(self.corrected_bf)
         return obj
+
+    def visualize(
+        self,
+        return_fig: bool = False,
+        **kwargs,
+    ):
+        """
+        Show the reconstructed object and its Hann-windowed Fourier transform.
+
+        Parameters
+        ----------
+        cbar : bool, optional
+            Whether to show colorbars, by default True.
+        return_fig : bool, optional
+            If True, return ``(fig, axs)``.
+        fft_norm : str | dict, optional
+            Normalization passed to ``show_2d`` for the object FFT.
+        **kwargs
+            Additional arguments passed to ``show_2d``.
+        """
+        if self.corrected_bf is None:
+            raise RuntimeError("Run reconstruct() before visualize().")
+
+        obj = self.obj
+        window = np.hanning(obj.shape[-2])[:, None] * np.hanning(obj.shape[-1])[None, :]
+        obj_fft = np.fft.fftshift(np.fft.fft2(obj * window))
+
+        obj_scalebar = {"sampling": self.scan_sampling[0], "units": "Å"}
+        fft_sampling = 1 / (self.scan_sampling[0] * obj.shape[-2])
+        fft_scalebar = {"sampling": fft_sampling, "units": r"$\mathrm{A^{-1}}$"}
+
+        fig, axs = show_2d(
+            [obj, np.abs(obj_fft)],
+            title=["Object", "Object FFT"],
+            scalebar=[obj_scalebar, fft_scalebar],
+            cmap=["magma", "magma"],
+            norm=[None, None],
+            **kwargs,
+        )
+        axs[1].set_aspect(obj.shape[-1] / obj.shape[-2])
+
+        if return_fig:
+            return fig, axs
+        return None
 
     def optimize_hyperparameters(
         self,

--- a/src/quantem/diffractive_imaging/direct_ptychography.py
+++ b/src/quantem/diffractive_imaging/direct_ptychography.py
@@ -61,19 +61,6 @@ def _rotation_degrees_to_radians(rotation_angle: float | None) -> float | None:
     return math.radians(float(rotation_angle))
 
 
-def _uses_aberration_orientation_convention(key: str) -> bool:
-    return key.startswith("phi") or key.endswith("_b")
-
-
-def _aberration_coefs_to_direct_convention(
-    aberration_coefs: dict[str, float | torch.Tensor],
-) -> dict[str, float | torch.Tensor]:
-    return {
-        key: -value if _uses_aberration_orientation_convention(key) else value
-        for key, value in aberration_coefs.items()
-    }
-
-
 @dataclass
 class OptimizationParameter:
     low: float
@@ -740,8 +727,6 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             aberration_coefs = state.current_aberrations(override_aberration_coefs)
             rotation_angle = state.current_rotation_angle(override_rotation_angle)
 
-        direct_aberration_coefs = _aberration_coefs_to_direct_convention(aberration_coefs)
-
         if upsampling_factor is None:
             upsampling_factor = 1
         upsampling_factor = math.ceil(upsampling_factor)
@@ -777,7 +762,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             dx, dy = aberration_surface_cartesian_gradients(
                 k * self.wavelength,
                 phi,
-                aberration_coefs=direct_aberration_coefs,
+                aberration_coefs=aberration_coefs,
             )
             grad_k = torch.stack((dx[bf_mask], dy[bf_mask]), -1)
 
@@ -786,7 +771,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
                     q * self.wavelength,
                     theta,
                     self.wavelength,
-                    aberration_coefs=direct_aberration_coefs,
+                    aberration_coefs=aberration_coefs,
                 )
                 sign_sin_chi_q = torch.sign(torch.sin(chi_q))
             else:
@@ -802,7 +787,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             self.semiangle_cutoff,
             self.angular_sampling,
             self.wavelength,
-            aberration_coefs=direct_aberration_coefs,
+            aberration_coefs=aberration_coefs,
         )
         BF_weights = cmplx_probe_k[bf_mask].abs().square().sum()
 
@@ -846,7 +831,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
                 cmplx_probe_k,
                 grad_k,
                 sign_sin_chi_q,
-                direct_aberration_coefs,
+                aberration_coefs,
                 batch_idx,
             )
             if power is None:
@@ -1175,8 +1160,6 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         aberration_coefs,
         bf_mask,
     ):
-        direct_aberration_coefs = _aberration_coefs_to_direct_convention(aberration_coefs)
-
         # Get initial shifts
         kxa, kya = spatial_frequencies(
             self.gpts,
@@ -1189,7 +1172,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
         dx, dy = aberration_surface_cartesian_gradients(
             k * self.wavelength,
             phi,
-            aberration_coefs=direct_aberration_coefs,
+            aberration_coefs=aberration_coefs,
         )
         grad_k = torch.stack((dx[bf_mask], dy[bf_mask]), -1)
         lateral_shifts = grad_k / 2 / np.pi
@@ -1331,8 +1314,8 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         self.corrected_stack = vbf_stack
 
-        fitted_rotation_angle = fit_results.pop("rotation_angle", None)
-        fitted_aberration_coefs = _aberration_coefs_to_direct_convention(fit_results)
+        fitted_aberration_coefs = fit_results.copy()
+        fitted_rotation_angle = fitted_aberration_coefs.pop("rotation_angle", None)
 
         state.optimized_aberrations = validate_aberration_coefficients(fitted_aberration_coefs)
         state.optimized_rotation_angle = fitted_rotation_angle
@@ -1392,7 +1375,6 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         device = self.device
         wavelength = self.wavelength
-        direct_aberration_coefs = _aberration_coefs_to_direct_convention(aberration_coefs)
 
         # ---------------------------------------------------------
         # Select strongest spatial frequencies
@@ -1444,9 +1426,9 @@ class DirectPtychography(RNGMixin, AutoSerialize):
             km * wavelength, phim, self.semiangle_cutoff, self.angular_sampling, soft_edges=True
         )
 
-        chi0 = aberration_surface(k0 * wavelength, phi0, wavelength, direct_aberration_coefs)
-        chip = aberration_surface(kp * wavelength, phip, wavelength, direct_aberration_coefs)
-        chim = aberration_surface(km * wavelength, phim, wavelength, direct_aberration_coefs)
+        chi0 = aberration_surface(k0 * wavelength, phi0, wavelength, aberration_coefs)
+        chip = aberration_surface(kp * wavelength, phip, wavelength, aberration_coefs)
+        chim = aberration_surface(km * wavelength, phim, wavelength, aberration_coefs)
 
         # ---------------------------------------------------------
         # Overlap-only masks
@@ -1565,8 +1547,7 @@ class DirectPtychography(RNGMixin, AutoSerialize):
 
         delta_cartesian = {name: sol[i] for i, name in enumerate(cartesian_basis)}
 
-        direct_merged = merge_aberration_coefficients(direct_aberration_coefs, delta_cartesian)
-        return _aberration_coefs_to_direct_convention(direct_merged)
+        return merge_aberration_coefficients(aberration_coefs, delta_cartesian)
 
     def fit_hyperparameters_least_squares(
         self,


### PR DESCRIPTION
### What problem this PR addreseses

This PR makes direct and iterative ptycho more consistent by changing direct ptycho to degrees and adding a visualize function. 

FWIW I did some testing yesterday, and I think the direction of aberrations is consistent between abTEM, direct, and iterative ptycho, but others should confirm as well. 

### What should the reviewer(s) do

Merge the code and provide feedback.
<img width="773" height="403" alt="visualize_output" src="https://github.com/user-attachments/assets/89ced6b2-2a6b-4f31-a5ea-45e76c8b25b1" />
