### PR TITLE
Normalizing by the quantile now an option in Tomo Dataset

### DIFF
--- a/src/quantem/tomography/dataset_models.py
+++ b/src/quantem/tomography/dataset_models.py
@@ -169,6 +169,7 @@ class TomographyDatasetBase(AutoSerialize, OptimizerMixin, nn.Module):
         tilt_angles: NDArray | torch.Tensor,
         learn_shift: bool = True,
         learn_tilt_axis: bool = True,
+        norm_quantile: bool = True,
         _token: object | None = None,
     ):
         AutoSerialize.__init__(self)
@@ -188,7 +189,10 @@ class TomographyDatasetBase(AutoSerialize, OptimizerMixin, nn.Module):
             tilt_stack = torch.from_numpy(tilt_stack)
         if type(tilt_angles) is not torch.Tensor:
             tilt_angles = torch.from_numpy(tilt_angles)
-        max_val = torch.quantile(tilt_stack, 0.95)
+        if norm_quantile:
+            max_val = torch.quantile(tilt_stack, 0.95)
+        else:
+            max_val = torch.max(tilt_stack)
 
         # Tilt stack normalization
         tilt_stack = tilt_stack / max_val
@@ -221,12 +225,14 @@ class TomographyDatasetBase(AutoSerialize, OptimizerMixin, nn.Module):
         tilt_angles: NDArray | torch.Tensor,
         learn_shift: bool = True,
         learn_tilt_axis: bool = True,
+        norm_quantile: bool = True,
     ):
         return cls(
             tilt_stack=tilt_stack,
             tilt_angles=tilt_angles,
             learn_shift=learn_shift,
             learn_tilt_axis=learn_tilt_axis,
+            norm_quantile=norm_quantile,
             _token=cls._token,
         )
 

--- a/src/quantem/tomography/dataset_models.py
+++ b/src/quantem/tomography/dataset_models.py
@@ -403,6 +403,7 @@ class TomographyPixDataset(TomographyDatasetConstraints):
         tilt_angles: NDArray | torch.Tensor,
         learn_shift: bool = True,
         learn_tilt_axis: bool = True,
+        norm_quantile: bool = True,
         _token: object | None = None,
     ):
         super().__init__(
@@ -410,6 +411,7 @@ class TomographyPixDataset(TomographyDatasetConstraints):
             tilt_angles=-tilt_angles,  # TODO: Flip the tilt angles to be negative to match the convention of INR.
             learn_shift=learn_shift,
             learn_tilt_axis=learn_tilt_axis,
+            norm_quantile=norm_quantile,
             _token=_token,
         )
 
@@ -462,10 +464,18 @@ class TomographyINRDataset(TomographyDatasetConstraints, Dataset):
         tilt_angles: NDArray | torch.Tensor,
         learn_shift: bool = True,
         learn_tilt_axis: bool = True,
+        norm_quantile: bool = True,
         seed: int = 42,
         _token: object | None = None,
     ):
-        super().__init__(tilt_stack, tilt_angles, learn_shift, learn_tilt_axis, _token=_token)
+        super().__init__(
+            tilt_stack,
+            tilt_angles,
+            learn_shift,
+            learn_tilt_axis,
+            norm_quantile,
+            _token=_token,
+        )
 
     # --- Forward Pass w/ Params Method for OptimizerMixin ---
     def forward(self, dummy_input: Any = None):


### PR DESCRIPTION
### What problem this PR addreseses

Auto-normalizing by quantile in Tomography for phantoms with majority zero values causes NaN values in optimization loop since the dataset is being divided by 0.

### What should the reviewer(s) do

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

Check @wwmills phantom does not diverge anymore.
